### PR TITLE
Changing author href

### DIFF
--- a/docs/.vitepress/theme/Components/Content/Contributors.vue
+++ b/docs/.vitepress/theme/Components/Content/Contributors.vue
@@ -4,7 +4,7 @@
 			<a
 				v-for="c in contributors"
 				:key="c.login"
-				:href="c.url"
+				:href="c.html_url"
 				:alt="c.login"
 				target="_blank"
 				class="h-8 w-8 transition-spacing ease-in-out duration-150"


### PR DESCRIPTION
Very minor change noticed when exploring the new website.

Updating the author href from "url" to "html_url". The [old wiki used html_url](https://github.com/Bedrock-OSS/bedrock-wiki/blob/gh-pages/_includes/head_custom.html#L210).