### PR TITLE
Sidemenu section logic

### DIFF
--- a/docs/.vitepress/theme/Components/Sidebar/Category.vue
+++ b/docs/.vitepress/theme/Components/Sidebar/Category.vue
@@ -8,10 +8,10 @@
 			border-b-1 border-true-gray-200
 			dark:border-true-gray-600
 		"
-		:open="isOpen"
+		:open="open"
 	>
 		<summary
-			@click.prevent.exact="isOpen = !isOpen"
+			@click.prevent.exact="emit('click')"
 			class="list-none outline-none"
 		>
 			<span>{{ props.item.text }}</span>
@@ -22,7 +22,7 @@
 		<div>
 			<NavLink
 				v-for="item in props.item.children"
-				@change="(val) => (val ? (isOpen = true) : undefined)"
+				@change="(val) => (val ? (emit('active')) : undefined)"
 				class="block"
 				:key="item.link"
 				:item="item"
@@ -35,13 +35,14 @@
 import type { INavCategory } from './Structure'
 import ChevronLeftIcon from '../Icons/ChevronLeftIcon.vue'
 import NavLink from '../Navigation/NavLink.vue'
-import { defineProps, ref } from 'vue'
+import { defineEmit, defineProps, ref } from 'vue'
 
 const props = defineProps<{
 	item: INavCategory
+	open: boolean
 }>()
 
-const isOpen = ref(false)
+const emit = defineEmit(['click', 'active'])
 </script>
 
 <style scoped>

--- a/docs/.vitepress/theme/Components/Sidebar/Navigation.vue
+++ b/docs/.vitepress/theme/Components/Sidebar/Navigation.vue
@@ -1,7 +1,11 @@
 <template>
 	<div>
-		<template v-for="item in props.items">
-			<Category :item="item" />
+		<template v-for="(item, i) in props.items">
+			<Category
+				:item="item"
+				:open="i === active || i === open"
+				@active="() => setActive(i)"
+				@click="() => setOpen(i)" />
 		</template>
 	</div>
 </template>
@@ -15,6 +19,22 @@ const props =
 	defineProps<{
 		items: INavCategory[]
 	}>()
+
+const active = ref<number>()
+const open = ref<number>()
+
+const setActive = (i: number) => {
+	active.value = i;
+}
+
+const setOpen = (i: number) => {
+	if (i === open.value) {
+		open.value = undefined;
+	}
+	else if (i !== active.value) {
+		open.value = i;
+	}
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
Changing how the logic of opening `Category` components is handled. #52 

- The active link's section is always forced open
- There can only be a single opened section at a time