### PR TITLE
Fixed "description" Error

### DIFF
--- a/docs/guide/custom-entity.md
+++ b/docs/guide/custom-entity.md
@@ -752,7 +752,6 @@ For us to now use these resources, we need to define them with a shortname. This
 	"format_version": "1.10.0",
 	"minecraft:client_entity": {
 		"description": {
-			"description": {
 			"identifier": "wiki:ghost",
 			"materials": {
 				"default": "entity_alphatest"
@@ -816,7 +815,6 @@ With that our entity file should look like this.
 	"format_version": "1.10.0",
 	"minecraft:client_entity": {
 		"description": {
-			"description": {
 			"identifier": "wiki:ghost",
 			"materials": {
 				"default": "entity_alphatest"


### PR DESCRIPTION
Removed double description in Entity RP Codes.

Description is written two times in two piece of codes.