### PR TITLE
Update fixed wiki-apply_team.mcfunction

### DIFF
--- a/docs/entities/disabling-team-damage.md
+++ b/docs/entities/disabling-team-damage.md
@@ -129,10 +129,10 @@ The process uses:
 <CodeHeader>BP/functions/wiki-apply_team.mcfunction</CodeHeader>
 
 ```
-execute @s[tag=team1] ~ ~ ~ tag @p[rm=0,r=1,type=arrow,tag=] team1
-execute @s[tag=team2] ~ ~ ~ tag @p[rm=0,r=1,type=arrow,tag=] team2
-execute @s[tag=team3] ~ ~ ~ tag @p[rm=0,r=1,type=arrow,tag=] team3
-execute @s[tag=team4] ~ ~ ~ tag @p[rm=0,r=1,type=arrow,tag=] team4
+execute @s[tag=team1] ~ ~ ~ tag @e[rm=0,r=1,c=1,type=arrow,tag=] add team1
+execute @s[tag=team2] ~ ~ ~ tag @e[rm=0,r=1,c=1,type=arrow,tag=] add team2
+execute @s[tag=team3] ~ ~ ~ tag @e[rm=0,r=1,c=1,type=arrow,tag=] add team3
+execute @s[tag=team4] ~ ~ ~ tag @e[rm=0,r=1,c=1,type=arrow,tag=] add team4
 
 ```
 


### PR DESCRIPTION
Changed @p to @e so that it would work on type=arrow.  Fixed command that left out the add.  Added selector c=1 to make sure it only applied to one arrow at a time.