### PR TITLE
Fix invalid JSON example in recipes documentation

### DIFF
--- a/docs/loot/recipes.md
+++ b/docs/loot/recipes.md
@@ -300,7 +300,7 @@ Shaped recipes enforce that the ingredients used during crafting conform to a st
 			"SSS",
 			"I I",
 			"I I"
-		]
+		],
 		"key": {
 			"S": "wiki:cloth",
 			"I": "wiki:support"


### PR DESCRIPTION
In the Shared Recipes section, the first code example is invalid.