### PR TITLE
fixed misinformation about the /agent command and it CAN actually be used to control player agents by using an NPC and the /execute commands with the /agent command

### DIFF
--- a/docs/entities/non-mob-runtime-identifiers.md
+++ b/docs/entities/non-mob-runtime-identifiers.md
@@ -2085,7 +2085,7 @@ The core behavior of `minecraft:elder_guardian_ghost` (applying mining fatigue a
 	* If `minecraft:nameable` is not active, `allow_name_tag_renaming` is considered as `false` and `always_show` is considered as `true`.
 	* If `minecraft:nameable` is active, `always_show` may be overridden, but `allow_name_tag_renaming` cannot be.
 	* On being owned, is named `§9Player.Agent`, where `Player` is the name of the owning player
-* Cannot be used as a player’s actual agent and cannot respond to the `/agent` command, even with NBT editing
+* Can only be used as a player's actual agent through the use of an NPC, the `/execute` command, and the `/agent` command, you can put this command into an npc button commands to make your agent turn left or to spawn in an agent if you don't already have one: "/execute as @initiator run /agent turn left", this command only works when run by an NPC. 
 
 #### Hardcoded Variables
 All variables are fixed due to custom entities not being able to use core agent functionality.


### PR DESCRIPTION
If you don’t believe me that the /agent commands CAN actually be used to control a player’s agent then just go on Minecraft and do this: 1. Summon an NPC. 2. In the NPC’s advanced settings add this button command “/execute as @initiator run /agent turn left”. 3. Open the NPC’s main dialogue box and click on the button you added with that command from the previous step. 4. Look on the ground next to you and you will see an agent. 5. Click the button in the NPC’s dialogue again and you will see that the agent has turned left by -90 degrees. This works with any /agent command but it HAS to be run by the NPC and you have to make the NPC use the /execute command so that the NPC runs it as you. 