### PR TITLE
Edit a typo in "textures" folder name

### DIFF
--- a/docs/guide/custom-item.md
+++ b/docs/guide/custom-item.md
@@ -166,7 +166,7 @@ To start we need a texture for our item. For our ectoplasm, we will be using thi
 
 <BButton link="https://raw.githubusercontent.com/Bedrock-OSS/wiki-addon/86b0380310d3d5748a43a4be1f93d4c59668e4bf/guide/guide_RP/textures/items/ectoplasm.png">Download texture here</BButton>
 
-All item textures are stored in `RP/texture/items/`. From here, you can create any subdirectories you wish.
+All item textures are stored in `RP/textures/items/`. From here, you can create any subdirectories you wish.
 It's best to name your texture image files with the items' _id_, in our case it will be `ectoplasm.png`.
 It is recommended to have your images in `.png` format and be of size `16x16`, though Minecraft will accept other formats such as `.jpg` or `.tga`.
 


### PR DESCRIPTION
I am currently following this guide and this typo just confused me, so I wanted to change it.