### PR TITLE
Fetch Mentioned Contributors

### DIFF
--- a/docs/.vitepress/theme/Components/Layout.vue
+++ b/docs/.vitepress/theme/Components/Layout.vue
@@ -129,7 +129,6 @@
 import {
 	computed,
 	reactive,
-	watchEffect,
 	onMounted,
 	defineAsyncComponent,
 } from 'vue'
@@ -152,7 +151,7 @@ onMounted(() => {
 
 const route = useRoute()
 const { page } = useData()
-const { toggle, isVisible } = useSidebarState()
+const { isVisible } = useSidebarState()
 
 function agreeCookies() {
 	document.cookie = 'bedrock-cookies=true; max-age=31536000 ; path=/'
@@ -189,7 +188,7 @@ const showEditLink = computed(
 )
 
 const mentionedContributors = computed(
-	() => routeData.value.frontmatter.mention ?? []
+	() => routeData.value.frontmatter.mentions ?? []
 )
 
 const tags = computed(() => routeData.value.frontmatter.tags ?? [])

--- a/docs/blocks/custom-glass-blocks.md
+++ b/docs/blocks/custom-glass-blocks.md
@@ -4,7 +4,7 @@ category: Vanilla Re-Creations
 tags:
     - experimental
     - expert
-mention:
+mentions:
     - Eko-byte
     - QuazChick
 ---

--- a/docs/blocks/custom-trees.md
+++ b/docs/blocks/custom-trees.md
@@ -3,7 +3,7 @@ title: Custom Trees
 category: Vanilla Re-Creations
 tags:
     - experimental
-mention:
+mentions:
     - MedicalJewel105
     - TheItsNameless
     - QuazChick

--- a/docs/guide/advancedmanifest.md
+++ b/docs/guide/advancedmanifest.md
@@ -3,12 +3,13 @@ title: Advanced Manifest
 category: Extra
 nav_order: 4
 prefix: 'd.'
-mention:
+mentions:
     - MRBBATES1
     - Luthorius
     - SirLich
     - smell-of-curry
     - MedicalJewel105
+    - QuazChick
 ---
 
 ::: tip


### PR DESCRIPTION
- Converted `mention` to `mentions` for page frontmatter.
  - Pages using `mention` have been changed to use `mentions`.
  - Pages using `mentions` now fetch mentioned contributors.