### PR TITLE
Fixed a typo in custom-glass-blocks.md

### DIFF
--- a/docs/blocks/custom-glass-blocks.md
+++ b/docs/blocks/custom-glass-blocks.md
@@ -88,7 +88,7 @@ Requires `Holiday Creator Features` for use of `minecraft:unit_cube` and to trig
         "group": "itemGroup.name.glass"
       },
       "properties": {
-        // Properties needed for connected textures, also contols up and down culling
+        // Properties needed for connected textures, also controls up and down culling
         "wiki:connected_state": [0, 1, 2, 3],
         // Properties to cull faces depending on surrounding blocks
         "wiki:cull_north": [false, true],


### PR DESCRIPTION
In the section `Vertically-Connecting Glass JSON` on line 12: Contols -> Controls