### PR TITLE
Prevent release of the menu button from toggling sidebar visibility

### DIFF
--- a/docs/.vitepress/theme/Components/Layout.vue
+++ b/docs/.vitepress/theme/Components/Layout.vue
@@ -8,6 +8,7 @@
 			:class="{
 				'md:ml-80': isVisible,
 			}"
+			@pointerdown="isMobile && isVisible && toggle()"
 		>
 			<h1
 				v-if="page && page.title"
@@ -139,6 +140,7 @@ import { useSidebarState } from '../Composables/sidebar'
 import { Content, useData, useRoute } from 'vitepress'
 import Label from './Content/Label.vue'
 import Button from './Content/Button.vue'
+import { useIsMobile } from '../Composables/isMobile'
 
 const Contributors = defineAsyncComponent(
 	() => import('./Content/Contributors.vue')
@@ -151,7 +153,8 @@ onMounted(() => {
 
 const route = useRoute()
 const { page } = useData()
-const { isVisible } = useSidebarState()
+const { isVisible, toggle } = useSidebarState()
+const { isMobile } = useIsMobile()
 
 function agreeCookies() {
 	document.cookie = 'bedrock-cookies=true; max-age=31536000 ; path=/'

--- a/docs/.vitepress/theme/Components/Navigation/NavBar.vue
+++ b/docs/.vitepress/theme/Components/Navigation/NavBar.vue
@@ -20,7 +20,7 @@
 		<component
 			:is="isVisible ? MenuOpenIcon : MenuIcon"
 			class="menu-icon mr-3 cursor-pointer"
-			@pointerdown.prevent="toggle()"
+			@pointerdown="toggle()"
 		/>
 
 		<a
@@ -56,7 +56,6 @@ import WikiLogo from '../Content/WikiLogo.vue'
 import { computed, defineAsyncComponent } from 'vue'
 import { useData } from 'vitepress'
 import { useSidebarState } from '../../Composables/sidebar'
-import { useIsMobile } from '../../Composables/isMobile'
 
 const AlgoliaSearchBox = defineAsyncComponent(
 	() => import('./AlgoliaSearch.vue')
@@ -66,8 +65,6 @@ const { toggle, isVisible } = useSidebarState()
 const { site } = useData()
 const navLinks = computed(() => site.value.themeConfig.nav)
 const algoliaConfig = computed(() => site.value.themeConfig.algolia)
-
-const { isMobile } = useIsMobile()
 </script>
 
 <style scoped>

--- a/docs/.vitepress/theme/Components/Sidebar/Sidebar.vue
+++ b/docs/.vitepress/theme/Components/Sidebar/Sidebar.vue
@@ -33,28 +33,12 @@
 
 <script setup lang="ts">
 import Navigation from './Navigation.vue'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useData } from 'vitepress'
 import { useSidebarState } from '../../Composables/sidebar'
-import { onClickOutside } from '@vueuse/core'
-import { useIsMobile } from '../../Composables/isMobile'
 
 const sidebarElement = ref<HTMLElement | null>(null)
-const { isVisible, toggle } = useSidebarState()
+const { isVisible } = useSidebarState()
 const { site } = useData()
 const navLinks = computed(() => site.value.themeConfig.sidebar['/'])
-const { isMobile } = useIsMobile()
-
-let dispose: (() => void) | undefined = undefined
-watch(isVisible, () => {
-	if (!isVisible.value) {
-		dispose?.()
-	} else {
-		setTimeout(() => {
-			dispose = onClickOutside(sidebarElement, () => {
-				if (isMobile.value && isVisible.value) toggle()
-			})
-		}, 100)
-	}
-})
 </script>


### PR DESCRIPTION
The mobile sidebar will now only be hidden if the user *starts* to press the menu button, or if the main page content is tapped.

Resolved #615