### PR TITLE
Added/removed new/old damage sources

### DIFF
--- a/docs/commands/damage.md
+++ b/docs/commands/damage.md
@@ -59,9 +59,10 @@ Introduced in Minecraft Release `1.18.10`, the /damage command deals precise dam
 
 Listed below are all the 'damage sources' in MCBE for the `/damage` command currently available:
 ```
+all
 anvil
-attack
 block_explosion
+campfire
 charging
 contact
 drowning
@@ -83,7 +84,9 @@ none
 override
 piston
 projectile
+ram_attack
 sonic_boom
+soul_campfire
 stalactite
 stalagmite
 starve


### PR DESCRIPTION
Removed `attack` as it's no longer valid in 1.20.40. Also added a few new ones listed on Microsoft's site: https://learn.microsoft.com/en-us/minecraft/creator/reference/content/addonsreference/examples/addonentities#entity-damage-source