### PR TITLE
Fix format of examples in recipes.md

### DIFF
--- a/docs/loot/recipes.md
+++ b/docs/loot/recipes.md
@@ -62,17 +62,17 @@ As an example, a "cold steel sword" might be crafted using the following [shaped
 			"I": "minecraft:stick"
 		},
 		"unlock": [
-            {
-              "item": "wiki:cold_steel"
-            },
 			{
-              "item": "minecraft:wool",
-            	"data":  3
+				"item": "wiki:cold_steel"
 			},
 			{
-			 "context": "PlayerInWater"
+				"item": "minecraft:wool",
+				"data":  3
+			},
+			{
+				"context": "PlayerInWater"
 			}
-          ],
+		],
 		"result": "wiki:cold_steel_sword"
 	}
 }
@@ -161,15 +161,15 @@ To effectively disable a recipe (useful for [overriding](#overrides) a prior rec
 Minecraft 1.20.30 added recipe unlocking to the game. In order to have your recipes use this function, you `manifest.json` must have a `min_engine_version` of 1.20.11 (1.20.30 is recommender). You also need to add the `unlock` array with its objects to your recipe.
 ```json
 		"unlock": [
-            {
-              "item": "wiki:cold_steel" //item to unlock recipe
-            },
 			{
-              "item": "minecraft:wool", //item to unlock recipe
-            	"data":  3
+				"item": "wiki:cold_steel" //item to unlock recipe
 			},
 			{
-			 "context": "PlayerInWater" //event to unlock recipe
+				"item": "minecraft:wool", //item to unlock recipe
+				"data":  3
+			},
+			{
+				"context": "PlayerInWater" //event to unlock recipe
 			}
           ]
 ```
@@ -298,17 +298,17 @@ Shapeless recipes simply bind a collection of inputs to a single output on a cra
 			}
 		],
 		"unlock": [
-            {
-              "item": "wiki:cold_steel"
-            },
 			{
-              "item": "minecraft:wool",
-            	"data":  3
+				"item": "wiki:cold_steel"
 			},
 			{
-			 "context": "PlayerInWater"
+				"item": "minecraft:wool",
+				"data":  3
+			},
+			{
+				"context": "PlayerInWater"
 			}
-          ],
+		],
 		"result": {
 			"item": "wiki:door_knob",
 			"data": 3
@@ -371,17 +371,17 @@ Shaped recipes enforce that the ingredients used during crafting conform to a st
 			"I": "wiki:support"
 		},
 		"unlock": [
-            {
-              "item": "wiki:cold_steel"
-            },
 			{
-              "item": "minecraft:wool",
-            	"data":  3
+				"item": "wiki:cold_steel"
 			},
 			{
-			 "context": "PlayerInWater"
+				"item": "minecraft:wool",
+				"data":  3
+			},
+			{
+				"context": "PlayerInWater"
 			}
-          ],
+		],
 		"result": [
 			{
 				"item": "wiki:covered_arch",
@@ -540,15 +540,15 @@ If a character in the pattern is not present in the key map, it will be treated 
 Minecraft 1.20.30 added recipe unlocking to the game. In order to have your recipes use this function, you `manifest.json` must have a `min_engine_version` of 1.20.11 (1.20.30 is recommender). You also need to add the `unlock` array with its objects to your recipe.
 ```json
 		"unlock": [
-            {
-              "item": "wiki:cold_steel" //item to unlock recipe
-            },
 			{
-              "item": "minecraft:wool", //item to unlock recipe
-            	"data":  3
+				"item": "wiki:cold_steel" //item to unlock recipe
 			},
 			{
-			 "context": "PlayerInWater" //event to unlock recipe
+				"item": "minecraft:wool", //item to unlock recipe
+				"data":  3
+			},
+			{
+				"context": "PlayerInWater" //event to unlock recipe
 			}
           ]
 ```

--- a/docs/loot/recipes.md
+++ b/docs/loot/recipes.md
@@ -550,7 +550,7 @@ Minecraft 1.20.30 added recipe unlocking to the game. In order to have your reci
 			{
 				"context": "PlayerInWater" //event to unlock recipe
 			}
-          ]
+		]
 ```
 Each object in this array contains `"item"` and this tells the recipe what item the player needs in their inventory in order for this recipe to be unlocked. `"context"` is used to determine what event unlocks this recipe. `"PlayerInWater"` will unlock this recipe when the player enters water. This is also the only known context for recipes.
 


### PR DESCRIPTION
There were a lot of lines using spaces instead of tabs.

Now fixed