### PR TITLE
Fix invalid JSON syntax in loot-tables.md

### DIFF
--- a/docs/loot/loot-tables.md
+++ b/docs/loot/loot-tables.md
@@ -234,7 +234,7 @@ Functions are what makes loot tables so powerful. They can do a wide range of ta
 	"type": "item",
 	"name": "minecraft:dirt",
 	"weight": 10,
-	"functions" [
+	"functions": [
 		{
 			"function": "set_count",
 			"count": {


### PR DESCRIPTION
Added a colon to an example in loot-tables.md to fix invalid JSON syntax.