### PR TITLE
Tool durability method for 1.20.40+

### DIFF
--- a/docs/items/tool-durability.md
+++ b/docs/items/tool-durability.md
@@ -92,7 +92,7 @@ function damage_item(item) {
 
 :::warning Experimental Script
 
-This script uses `@minecraft/server 1.8.0-beta`, which will change in the next minecraft update.
+This script uses `@minecraft/server 1.9.0-beta`, which will change in the next minecraft update.
 :::
 
 For format versions 1.20.40 and onward, `on_hurt_entity` no longer works.
@@ -154,7 +154,7 @@ world.afterEvents.entityHurt.subscribe(event => {
 
 :::warning Experimental Script
 
-This script uses `@minecraft/server 1.8.0-beta`, which will change in the next minecraft update.
+This script uses `@minecraft/server 1.9.0-beta`, which will change in the next minecraft update.
 :::
 
 For format versions 1.20.20 and onward, `on_dig` no longer works.

--- a/docs/items/tool-durability.md
+++ b/docs/items/tool-durability.md
@@ -111,8 +111,28 @@ This provides a way to damage weapons using scripts
 // Add your item IDs into this array
 const my_items = ["wiki:silver_dagger"]
 
+world.afterEvents.entityHurt.subscribe(event => {
+    // If there's no source entity, skip
+    if (!event.damageSource.damagingEntity) return
 
+    // Get equipped weapon
+    const equipment = event.damageSource.damagingEntity.getComponent("minecraft:equippable")
+    if (!equipment) return
+    const weapon = equipment.getEquipment(EquipmentSlot.Mainhand)
 
+    // If there's no weapon, skip
+    if (!weapon) return
+
+    // If the item is not in our item IDs, skip
+    if (!my_items.includes(weapon.typeId)) return
+    let newItem = damage_item(weapon)
+    equipment.setEquipment(EquipmentSlot.Mainhand, newItem)
+    if (!newItem) {
+        if (event.damageSource.damagingEntity instanceof Player) {
+            event.damageSource.damagingEntity.playSound("random.break")
+        }
+    }
+})
 ```
 
 ### on_hurt_entity

--- a/docs/items/tool-durability.md
+++ b/docs/items/tool-durability.md
@@ -4,14 +4,12 @@ category: Tutorials
 tags:
     - experimental
     - intermediate
+    - scripting
 mentions:
     - MedicalJewel105
     - TheDoctor15
+    - napstaa967
 ---
-
-:::warning
-`on_dig` in items have been removed from the game, so this tutorial won't help you. If you know the way, please, contribute! 
-:::
 
 ## Introduction
 
@@ -19,18 +17,38 @@ mentions:
 Now you need to define when will the item get durability damage and also an event that does it.
 What will be discussed on this page:
 
--	Event that updates durability
--	`on_hurt_entity` durability update
--	`on_dig` durability update
--	`repair_amount` value
--	`on_tool_used` event
+- Durability component
+
+- Event that updates durability
+
+- Damaging entities
+
+- Block breaking
+
+- `repair_amount` value
+
+- `on_tool_used` event
+
+### Components
+
+<CodeHeader>BP/items/my_item.json#components</CodeHeader>
+
+```json
+"minecraft:durability": {
+    "max_durability": 200
+}
+```
+
+`minecraft:durability` will give your item a set max durability
 
 ## Event
+
+### Item event
 
 <CodeHeader>BP/items/my_item.json#events</CodeHeader>
 
 ```json
-"durability_update": {
+"your_mod:durability_update": {
     "damage": {
         "type": "none",
         "amount": 1,
@@ -42,7 +60,67 @@ What will be discussed on this page:
 When this event is called the item (`self` target) will receive durability damage.
 Looks simple, doesn't it?
 
-## on_hurt_entity
+### Script event
+
+For the script methods, we'll be using a function to damage our item
+
+This function supports unbreaking on items
+
+<CodeHeader>BP/scripts/main.js</CodeHeader>
+
+```js
+function damage_item(item) {
+    // Get durability
+    const durabilityComponent = item.getComponent("durability")
+    var unbreaking = 0
+    // Get unbreaking level
+    if (item.hasComponent("enchantments")) {
+        unbreaking = item.getComponent("enchantments").enchantments.getEnchantment("unbreaking")
+        if (!unbreaking) {
+            unbreaking = 0
+        } else {
+            unbreaking = unbreaking.level
+        }
+    }
+    // Apply damage
+    if (durabilityComponent.damage == durabilityComponent.maxDurability) {
+
+        return
+    }
+    durabilityComponent.damage += Number(Math.round(Math.random() * 100) <= durabilityComponent.getDamageChance(unbreaking))
+    return item
+}
+```
+
+## Damaging entities
+
+### Using scripts
+
+:::warning Experimental Script
+
+This script uses `@minecraft/server 1.8.0-beta`, which will change in the next minecraft update.
+:::
+
+For format versions 1.20.40 and onward, `on_hurt_entity` no longer works.
+
+This provides a way to damage weapons using scripts
+
+<CodeHeader>BP/scripts/main.js</CodeHeader>
+
+```js
+// Add your item IDs into this array
+const my_items = ["wiki:silver_dagger"]
+
+
+
+```
+
+### on_hurt_entity
+
+:::warning
+
+`on_hurt_entity` was removed in format version 1.20.40
+:::
 
 `on_hurt_entity` can be defined in "minecraft:weapon" component. It tells the game what event should happen when player hurts entity using this item.
 
@@ -51,12 +129,54 @@ Looks simple, doesn't it?
 ```json
 "minecraft:weapon": {
     "on_hurt_entity": {
-        "event": "durability_update"
+        "event": "your_mod:durability_update"
     }
 }
 ```
 
-## on_dig
+## Block breaking
+
+### Using scripts
+
+:::warning Experimental Script
+
+This script uses `@minecraft/server 1.8.0-beta`, which will change in the next minecraft update.
+:::
+
+For format versions 1.20.20 and onward, `on_dig` no longer works.
+
+This provides a way to damage digger items by using scripts
+
+<CodeHeader>BP/scripts/main.js</CodeHeader>
+
+```js
+// Add your item IDs into this array
+const my_items = ["wiki:obsidian_pickaxe"]
+
+world.afterEvents.playerBreakBlock.subscribe(event => {
+    // If there's no item, skip
+    if (!event.itemStackAfterBreak) return
+    // If the item is not in our item IDs, skip
+    if (!my_items.includes(event.itemStackAfterBreak.typeId)) return
+
+    // If player is in creative, skip
+    if (world.getPlayers({
+        gameMode: GameMode.creative
+    }).includes(event.player)) return
+    const newItem = damage_item(event.itemStackAfterBreak)
+    event.player.getComponent("minecraft:equippable").setEquipment(EquipmentSlot.Mainhand, newItem)
+    if (!newItem) {
+        event.player.playSound("random.break")
+    }
+})
+```
+
+### on_dig
+
+:::warning
+
+`on_dig` was removed in format version 1.20.20
+:::
 
 `on_dig` can be defined in "minecraft:digger" component. It tells the game what event should happen when player dug a block using this item.
 
@@ -72,14 +192,14 @@ Looks simple, doesn't it?
             },
             "speed": 8,
             "on_dig": {
-				// Defines event that should happen when block with tag wood was dug.
+                // Defines event that should happen when block with tag wood was dug.
                 "event": "durability_update"
             }
         }
     ],
     "on_dig": {
-		// Defines event that should happen when any block was destroyed.
-        "event": "durability_update"
+        // Defines event that should happen when any block was destroyed.
+        "event": "your_mod:durability_update"
     }
 }
 ```
@@ -117,12 +237,12 @@ The _final_ durability will be durability of the first axe + durability of the s
 Tags work kinda like runtime identifiers for entities.
 Known tags:
 
-| Tag                  | Effects           | How can be called                                  |
-| -------------------- | ----------------- | -------------------------------------------------- |
-| minecraft:is_axe     | Strips logs       | By interacting with blocks that axe interacts with |
-| minecraft:is_hoe     | Makes farmland    | By interacting with blocks that hoe interacts with |
-| minecraft:is_pickaxe | Unknown           | Unknown                                            |
-| minecraft:is_sword   | Unknown           | Unknown                                            |
+| Tag                  | Effects        | How can be called                                  |
+| -------------------- | -------------- | -------------------------------------------------- |
+| minecraft:is_axe     | Strips logs    | By interacting with blocks that axe interacts with |
+| minecraft:is_hoe     | Makes farmland | By interacting with blocks that hoe interacts with |
+| minecraft:is_pickaxe | Unknown        | Unknown                                            |
+| minecraft:is_sword   | Unknown        | Unknown                                            |
 
 You can apply these tags this way:
 

--- a/docs/items/tool-durability.md
+++ b/docs/items/tool-durability.md
@@ -16,17 +16,11 @@ mentions:
 1.16.100+ items have different durability mechanic than 1.10 and 1.16 items.
 Now you need to define when will the item get durability damage and also an event that does it.
 What will be discussed on this page:
-
 - Durability component
-
 - Event that updates durability
-
 - Damaging entities
-
 - Block breaking
-
 - `repair_amount` value
-
 - `on_tool_used` event
 
 ### Components
@@ -48,7 +42,7 @@ What will be discussed on this page:
 <CodeHeader>BP/items/my_item.json#events</CodeHeader>
 
 ```json
-"your_mod:durability_update": {
+"durability_update": {
     "damage": {
         "type": "none",
         "amount": 1,
@@ -149,7 +143,7 @@ world.afterEvents.entityHurt.subscribe(event => {
 ```json
 "minecraft:weapon": {
     "on_hurt_entity": {
-        "event": "your_mod:durability_update"
+        "event": "durability_update"
     }
 }
 ```
@@ -219,7 +213,7 @@ world.afterEvents.playerBreakBlock.subscribe(event => {
     ],
     "on_dig": {
         // Defines event that should happen when any block was destroyed.
-        "event": "your_mod:durability_update"
+        "event": "durability_update"
     }
 }
 ```


### PR DESCRIPTION
Starting 1.20.40, `minecraft:weapon` is no longer supported.
This adds a way to replace `on_dig` and `on_entity_hurt` by using scripting, which also adds support for unbreaking.