### PR TITLE
Warning about block events

### DIFF
--- a/docs/blocks/block-events.md
+++ b/docs/blocks/block-events.md
@@ -28,7 +28,7 @@ Using the latest format version when creating custom blocks provides access to f
 Block events require the `Holiday Creator Features` experiment to be enabled.
 :::
 :::danger WARNING
-Block events are deprecated, and will be removed in a future update. It is not reccomended to use them unless absolutely necessary, as you will need to convert all functionality from them to scripts once they are removed.
+Block events are deprecated, and will be removed in a future update. It is not recommended to use them unless absolutely necessary, as you will need to convert all functionality from them to scripts once they are removed.
 :::
 
 ## Defining Events

--- a/docs/blocks/block-events.md
+++ b/docs/blocks/block-events.md
@@ -18,6 +18,7 @@ mentions:
     - ThomasOrs
     - QuazChick
     - VactricaKing
+    - BlazeDrake
 ---
 
 :::tip FORMAT & MIN ENGINE VERSION `1.20.30`
@@ -25,6 +26,9 @@ Using the latest format version when creating custom blocks provides access to f
 :::
 :::warning EXPERIMENTAL
 Block events require the `Holiday Creator Features` experiment to be enabled.
+:::
+:::danger WARNING
+Block events are deprecated, and will be removed in a future update. It is not reccomended to use them unless absolutely necessary, as you will need to convert all functionality from them to scripts once they are removed.
 :::
 
 ## Defining Events


### PR DESCRIPTION
I added a warning about how block events will soon be removed to the wiki page on them. The reason I did this is so that people don't rely on them too much, and so it's less surprising to people who aren't in the discord when they do get removed.