### PR TITLE
Revert "Removed warning"

### DIFF
--- a/docs/blocks/precise-rotation.md
+++ b/docs/blocks/precise-rotation.md
@@ -14,6 +14,10 @@ This tutorial assumes an advanced understanding of blocks and Molang.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
 
+::: warning EXPERIMENTAL
+Requires `Holiday Creator Features` to trigger events.
+:::
+
 This tutorial guides you through making a block with sub-cardinal rotation (e.g. creeper heads and signs), providing examples of a "shell" block with this rotation type.
 
 *Looking for regular rotation? Learn about it [here](/blocks/rotatable-blocks)!*


### PR DESCRIPTION
Reverts Bedrock-OSS/bedrock-wiki#821
Experimental is still needed. It seems I confused when testing the pack in the wrong world. Sorry for any inconvenience!