### PR TITLE
Typo fix in understanding-json.md

### DIFF
--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -138,7 +138,7 @@ First, create a new file in your BP folder by right-clicking on the folder and s
 
 -   "`version`" defines the version of your add-on. When you import an add-on with a newer version on a device with an older version installed, the more recent version will overwrite the older one. You don't need to change the version if you have the add-on in `development_*_packs` folders and only use them on private worlds.
 
--   "`min_engine_version`" defines the minimum Minecraft client version that'll be able to read your add-on.
+-   "`min_engine_version`" defines the minimum Minecraft client version that'll be able to read your add-on. The number specified here should match the version number of the game, unless you're planning for backwards compatibility with older versions.
 
 -   In "`modules`", the "`type`" is defined to be "`data`". This makes your pack a _Behavior Pack_.
 

--- a/docs/guide/understanding-json.md
+++ b/docs/guide/understanding-json.md
@@ -126,7 +126,7 @@ Take a careful look at the format. You will see that the entire structure is bui
 
 ## Troubleshooting Examples
 
-Here are a few examples, to help you understand feedback you might recieve on the discord or online. We tend to use technical jargon when talking about errors in JSON, so hopefully this section helps familizrize you with the terms: 
+Here are a few examples, to help you understand feedback you might recieve on the discord or online. We tend to use technical jargon when talking about errors in JSON, so hopefully this section helps familiarize you with the terms: 
 
 ---
 


### PR DESCRIPTION
There was a one letter typo in the word "familiarize". 
Also added a slightly more specific description for what "min_engine_version" means in a manifest.json.