### PR TITLE
Update block-shapes.md

### DIFF
--- a/docs/blocks/block-shapes.md
+++ b/docs/blocks/block-shapes.md
@@ -126,5 +126,6 @@ They are added in the resource pack's file, `blocks.json`, using child `"blocksh
 | 133 | flowering_azalea          |
 | 134 | glow_frame                |
 | 135 | glow_lichen               |
+| 136 | redstone_wire"            |
 
 [ Original Credit ](https://gist.github.com/toka7290/3bef704d2f57c775bb9ac84443a6df1c)


### PR DESCRIPTION
Redstone_wire is a valid block shape that adapts to the shape next to it by rotating in a strange way