### PR TITLE
Updated Applying Constant Effects Tutorial

### DIFF
--- a/docs/blocks/applying-effects.md
+++ b/docs/blocks/applying-effects.md
@@ -82,6 +82,8 @@ world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
 
 ## Applying Effects to Treaders
 
+### Block JSON
+
 We also need the block to tick in order to apply the desired effect every tick. For this, we'll use the [permutations](/blocks/block-permutations) array so a custom component is only applied if the block is being stepped on:
 
 <CodeHeader>minecraft:block</CodeHeader>
@@ -100,6 +102,8 @@ We also need the block to tick in order to apply the desired effect every tick. 
     }
 ]
 ```
+
+### Custom Component Script
 
 Now, let's add our event that will give the entity the wither effect:
 

--- a/docs/blocks/block-components.md
+++ b/docs/blocks/block-components.md
@@ -40,12 +40,15 @@ Block components are used to change how your block appears and functions in the 
     "format_version": "1.21.0",
     "minecraft:block": {
         "description": {
-            "identifier": "wiki:custom_block",
+            "identifier": "wiki:lamp",
             "menu_category": {
                 "category": "items"
             }
         },
         "components": {
+            "minecraft:light_dampening": 0,
+            "minecraft:light_emission": 15,
+            "minecraft:map_color": [210, 200, 190],
             "minecraft:geometry": "geometry.lamp",
             "minecraft:material_instances": {
                 "*": {
@@ -62,16 +65,16 @@ Block components are used to change how your block appears and functions in the 
 
 ## Collision Box
 
-Defines the area of the block that collides with entities. If set to true, default values are used. If set to false, the block's collision with entities is disabled. If this component is omitted, default values are used. 
+Defines the area of the block that collides with entities. If set to true, default values are used. If set to false, the block's collision with entities is disabled. If this component is omitted, default values are used.
 
 _Released from experiment `Holiday Creator Features` for format versions `1.19.50` and higher._
 
 Type: Boolean/Object
 
-- `origin`: Vector [a, b, c]
-    - Minimal position of the bounds of the collision box. `origin` is specified as `[x, y, z]` and must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
--  `size`: Vector [a, b, c]
-    - Size of each side of the collision box. Size is specified as `[x, y, z]`. `origin` + `size` must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
+-   `origin`: Vector [a, b, c]
+    -   Minimal position of the bounds of the collision box. `origin` is specified as `[x, y, z]` and must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
+-   `size`: Vector [a, b, c]
+    -   Size of each side of the collision box. Size is specified as `[x, y, z]`. `origin` + `size` must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
 
 ### Example using Boolean
 
@@ -100,11 +103,11 @@ _Released from experiment `Holiday Creator Features` for format versions `1.19.5
 
 Type: Object
 
-- `crafting_tags`: Array
-    - Required Field
-    - Defines the tags recipes should define to be crafted on this table. Limited to 64 tags. Each tag is limited to 64 characters.
-- `table_name`: String
-    - Specifies the language file key that maps to what text will be displayed in the UI of this table. If the string given can not be resolved as a loc string, the raw string given will be displayed. If this field is omitted, the name displayed will default to the name specified in the "display_name" component. If this block has no "display_name" component, the name displayed will default to the name of the block.
+-   `crafting_tags`: Array
+    -   Required Field
+    -   Defines the tags recipes should define to be crafted on this table. Limited to 64 tags. Each tag is limited to 64 characters.
+-   `table_name`: String
+    -   Specifies the language file key that maps to what text will be displayed in the UI of this table. If the string given can not be resolved as a loc string, the raw string given will be displayed. If this field is omitted, the name displayed will default to the name specified in the "display_name" component. If this block has no "display_name" component, the name displayed will default to the name of the block.
 
 <CodeHeader>minecraft:block > components</CodeHeader>
 
@@ -124,8 +127,8 @@ Describes the destructible by explosion properties for this block. If set to tru
 
 Type: Boolean/Object
 
-- `explosion_resistance`: Double
-    - Describes how resistant the block is to explosion. Greater values mean the block is less likely to break when near an explosion (or has higher resistance to explosions). The scale will be different for different explosion power levels. A negative value or 0 means it will easily explode; larger numbers increase level of resistance.
+-   `explosion_resistance`: Double
+    -   Describes how resistant the block is to explosion. Greater values mean the block is less likely to break when near an explosion (or has higher resistance to explosions). The scale will be different for different explosion power levels. A negative value or 0 means it will easily explode; larger numbers increase level of resistance.
 
 ### Example using Boolean
 
@@ -151,9 +154,9 @@ Describes the destructible by mining properties for this block. If set to true, 
 
 Type: Boolean/Object
 
-- `seconds_to_destroy`: Double
-    - Sets the number of seconds it takes to destroy the block with base equipment. Greater numbers result in greater mining times.
-    - Note: It actually takes 2x the amount of seconds defined.\
+-   `seconds_to_destroy`: Double
+    -   Sets the number of seconds it takes to destroy the block with base equipment. Greater numbers result in greater mining times.
+    -   Note: It actually takes 2x the amount of seconds defined.\
 
 ### Example using Boolean
 
@@ -209,8 +212,8 @@ Describes the flammable properties for this block. If set to true, default value
 
 Type: Boolean/Object
 
-- `catch_chance_modifier`: Int
-    - A modifier affecting the chance that this block will catch flame when next to a fire. Values are greater than or equal to 0, with a higher number meaning more likely to catch on fire. For a `catch_chance_modifier` greater than 0, the fire will continue to burn until the block is destroyed (or it will burn forever if the `destroy_chance_modifier` is 0). If the `catch_chance_modifier` is 0, and the block is directly ignited, the fire will eventually burn out without destroying the block (or it will have a chance to be destroyed if `destroy_chance_modifier` is greater than 0). The default value of 5 is the same as that of Planks.
+-   `catch_chance_modifier`: Int
+    -   A modifier affecting the chance that this block will catch flame when next to a fire. Values are greater than or equal to 0, with a higher number meaning more likely to catch on fire. For a `catch_chance_modifier` greater than 0, the fire will continue to burn until the block is destroyed (or it will burn forever if the `destroy_chance_modifier` is 0). If the `catch_chance_modifier` is 0, and the block is directly ignited, the fire will eventually burn out without destroying the block (or it will have a chance to be destroyed if `destroy_chance_modifier` is greater than 0). The default value of 5 is the same as that of Planks.
 
 ### Example using Boolean
 
@@ -261,11 +264,11 @@ _Released from experiment `Holiday Creator Features` for format versions 1.19.40
 
 Type: String/Object
 
-- `identifier`: String
-    - The identifier of the geometry.
-- `bone_visibility`: Object
-    - Optional “array” of Booleans that define the visibility of individual bones in the geometry file. In order to set up bone_visibility the geometry file name must be entered as an identifier. After the identifier has been specified, bone_visibility can be defined based on the names of the bones in the specified geometry file on a true/false basis.
-    - Note that all bones default to true, so bones should only be defined if they are being set to false. Including bones set to true will work the same as the default.
+-   `identifier`: String
+    -   The identifier of the geometry.
+-   `bone_visibility`: Object
+    -   Optional “array” of Booleans that define the visibility of individual bones in the geometry file. In order to set up bone_visibility the geometry file name must be entered as an identifier. After the identifier has been specified, bone_visibility can be defined based on the names of the bones in the specified geometry file on a true/false basis.
+    -   Note that all bones default to true, so bones should only be defined if they are being set to false. Including bones set to true will work the same as the default.
 
 ### Example using String
 
@@ -456,19 +459,20 @@ _Released from experiment `Holiday Creator Features` for format versions 1.19.60
 
 Type: Object
 
-- `conditions`: Array - List of conditions where the block can be placed/survive. Limited to 64 conditions. Each condition is a JSON Object that must contain at least one (and can contain both) of the parameters `allowed_faces` or `block_filter` as shown below.
-    - `allowed_faces`: Array - List of any of the following strings describing which face(s) this block can be placed on: `up`, `down`, `north`, `south`, `east`, `west`, `side`, `all`. Limited to 6 faces.
-    - `block_filter`: Array - List of blocks that this block can be placed against in the `allowed_faces` direction. Limited to 64 blocks. Each block in this list can either be specified as a String (block name) or as a BlockDescriptor.
+-   `conditions`: Array - List of conditions where the block can be placed/survive. Limited to 64 conditions. Each condition is a JSON Object that must contain at least one (and can contain both) of the parameters `allowed_faces` or `block_filter` as shown below.
+    -   `allowed_faces`: Array - List of any of the following strings describing which face(s) this block can be placed on: `up`, `down`, `north`, `south`, `east`, `west`, `side`, `all`. Limited to 6 faces.
+    -   `block_filter`: Array - List of blocks that this block can be placed against in the `allowed_faces` direction. Limited to 64 blocks. Each block in this list can either be specified as a String (block name) or as a BlockDescriptor.
 
 ### Block Descriptor
+
 A BlockDescriptor is an object that allows you to reference a block (or multiple blocks) based on its tags, or based on its name and states. The fields of a BlockDescriptor are described below.
 
-- `name`: String
-    - The name of a block.
-- `states`: Object
-    - The list of Vanilla block states and their values that the block can have, expressed in key/value pairs.
-- `tags`: String
-    - A condition using Molang queries that results to true/false that can be used to query for blocks with certain tags.
+-   `name`: String
+    -   The name of a block.
+-   `states`: Object
+    -   The list of Vanilla block states and their values that the block can have, expressed in key/value pairs.
+-   `tags`: String
+    -   A condition using Molang queries that results to true/false that can be used to query for blocks with certain tags.
 
 <CodeHeader>minecraft:block > components</CodeHeader>
 
@@ -506,10 +510,10 @@ _Released from experiment `Holiday Creator Features` for format versions 1.19.60
 
 Type: Boolean/Object
 
-- `origin`: Vector [a, b, c]
-    - Minimal position of the bounds of the collision box. `origin` is specified as `[x, y, z]` and must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
--  `size`: Vector [a, b, c]
-    - Size of each side of the collision box. Size is specified as `[x, y, z]`. `origin` + `size` must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
+-   `origin`: Vector [a, b, c]
+    -   Minimal position of the bounds of the collision box. `origin` is specified as `[x, y, z]` and must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
+-   `size`: Vector [a, b, c]
+    -   Size of each side of the collision box. Size is specified as `[x, y, z]`. `origin` + `size` must be in the range `(-8, 0, -8)` to `(8, 16, 8)`, inclusive.
 
 ### Example using Boolean
 
@@ -542,16 +546,16 @@ Lean about [rotatable blocks](/blocks/rotatable-blocks) to apply rotation based 
 
 Type: Object
 
-- `rotation`: Vector [a, b, c]
-    - How many degrees to rotate the geometry. [x ,y, z]. Must be in increments of 90. Can be negative. If not in increment of 90, the game will round to the nearest 90 increment.
-- `rotation_pivot`: Vector [a, b, c]
-    - The pivot point(in block units) to rotate the block on.
-- `scale`: Vector [a, b, c]
-    - How many pixels to scale the geometry. [x ,y, z]
-- `scale_pivot`: Vector [a, b, c]
-    - The pivot point(in block units) to scale the block on.
-- `translation`: Vector [a, b, c]
-    - How many pixels to translate the geometry. [x ,y, z]
+-   `rotation`: Vector [a, b, c]
+    -   How many degrees to rotate the geometry. [x ,y, z]. Must be in increments of 90. Can be negative. If not in increment of 90, the game will round to the nearest 90 increment.
+-   `rotation_pivot`: Vector [a, b, c]
+    -   The pivot point(in block units) to rotate the block on.
+-   `scale`: Vector [a, b, c]
+    -   How many pixels to scale the geometry. [x ,y, z]
+-   `scale_pivot`: Vector [a, b, c]
+    -   The pivot point(in block units) to scale the block on.
+-   `translation`: Vector [a, b, c]
+    -   How many pixels to translate the geometry. [x ,y, z]
 
 <CodeHeader>minecraft:block > components</CodeHeader>
 

--- a/docs/blocks/block-events.md
+++ b/docs/blocks/block-events.md
@@ -45,8 +45,11 @@ const CreativeModeOnlyComponent = {
     },
 };
 
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-    blockTypeRegistry.registerCustomComponent("wiki:creative_mode_only", CreativeModeOnlyComponent);
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent(
+        "wiki:creative_mode_only",
+        CreativeModeOnlyComponent
+    );
 });
 ```
 

--- a/docs/blocks/block-sounds.md
+++ b/docs/blocks/block-sounds.md
@@ -14,7 +14,7 @@ This property is used to determine general block sounds, such as the mining soun
 
 ```json
 {
-    "format_version": [1, 1, 0],
+    "format_version": "1.21.20",
     "wiki:custom_log": {
         "sound": "wood" // Define sound here
     }

--- a/docs/blocks/blocks-intro.md
+++ b/docs/blocks/blocks-intro.md
@@ -134,7 +134,7 @@ If you'd like to apply a custom model, the [geometry](/blocks/block-components#g
 
 ```json
 {
-    "format_version": [1, 1, 0],
+    "format_version": "1.21.20",
     "wiki:custom_block": {
         "textures": "custom_block", // This texture shortname should be defined in `terrain_texture.json`, as shown below
         "sound": "grass"
@@ -222,7 +222,7 @@ The `blocks.json` entry would look like this:
 
 ```json
 {
-    "format_version": [1, 1, 0],
+    "format_version": "1.21.20",
     "wiki:compass_block": {
         "textures": {
             "down": "compass_block_down",

--- a/docs/blocks/custom-crops.md
+++ b/docs/blocks/custom-crops.md
@@ -143,8 +143,8 @@ const CustomCropGrowthBlockComponent = {
     },
 };
 
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-    blockTypeRegistry.registerCustomComponent(
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent(
         "wiki:custom_crop_growth",
         CustomCropGrowthBlockComponent
     );

--- a/docs/blocks/custom-trees.md
+++ b/docs/blocks/custom-trees.md
@@ -1031,7 +1031,7 @@ Add sounds to blocks
 
 ```json
 {
-    "format_version": [1, 1, 0],
+    "format_version": "1.21.20",
     "wiki:custom_leaves": {
         "sound": "grass"
     },

--- a/docs/blocks/fake-blocks.md
+++ b/docs/blocks/fake-blocks.md
@@ -89,9 +89,7 @@ First, in the `minecraft:entity_spawned` event, make a custom block with a run_c
             ]
         },
         "run_command": {
-            "command": [
-                "setblock ~~~ wiki:align"
-            ]
+            "command": ["setblock ~~~ wiki:align"]
         }
     }
 }
@@ -135,9 +133,7 @@ Block used to summon the dummy entity right on the block, and as the block is ce
             "minecraft:destructible_by_mining": {
                 "seconds_to_destroy": 2
             },
-            "minecraft:custom_components": [
-                "wiki:on_placed_align"
-            ]
+            "minecraft:custom_components": ["wiki:on_placed_align"]
         }
     }
 }
@@ -152,15 +148,14 @@ const wikiOnPlacedAlign = {
     beforeOnPlayerPlace(event) {
         event.cancel = true;
         let blockLocation = event.block.location;
-        event.player.dimension.spawnEntity('wiki:dummy_align', blockLocation);
-    }
-}
+        event.player.dimension.spawnEntity("wiki:dummy_align", blockLocation);
+    },
+};
 
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-    blockTypeRegistry.registerCustomComponent("wiki:on_placed_align", wikiOnPlacedAlign);
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent("wiki:on_placed_align", wikiOnPlacedAlign);
 });
 ```
-
 
 <CodeHeader>BP/entities/your_dummy_entity.json</CodeHeader>
 
@@ -200,9 +195,7 @@ world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
         "events": {
             "minecraft:entity_spawned": {
                 "add": {
-                    "component_groups": [
-                        "transform"
-                    ]
+                    "component_groups": ["transform"]
                 }
             }
         }

--- a/docs/blocks/ore-loot-tables.md
+++ b/docs/blocks/ore-loot-tables.md
@@ -25,16 +25,16 @@ This tutorial aims to show a new way of creating custom ore blocks with a proper
 
 In addition, through use of scripts and custom components, we can create the experience orb reward offered by vanilla ores if the correct tool is used to destroy the block.
 
-- Features:
+-   Features:
 
-  -   Can be mined using any given item (this tutorial covers the iron pickaxe)
-  -   Can specify enchantments on items
-  -   Also drops experience reward
+    -   Can be mined using any given item (this tutorial covers the iron pickaxe)
+    -   Can specify enchantments on items
+    -   Also drops experience reward
 
-- Issues:
+-   Issues:
 
-  -   All items must be specified individually
-  -   Non-player methods of breaking the block (explosions, commands, etc.) will fail to drop the loot
+    -   All items must be specified individually
+    -   Non-player methods of breaking the block (explosions, commands, etc.) will fail to drop the loot
 
 ## Loot Table
 
@@ -44,24 +44,24 @@ In the example below, you can see how the `match_tool` condition is used to test
 
 ```json
 {
-  "pools": [
-    {
-      "rolls": 1,
-      "conditions": [
+    "pools": [
         {
-          "condition": "match_tool",
-          "item": "minecraft:iron_pickaxe",
-          "count": 1
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "match_tool",
+                    "item": "minecraft:iron_pickaxe",
+                    "count": 1
+                }
+            ],
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "wiki:raw_silver"
+                }
+            ]
         }
-      ],
-      "entries": [
-        {
-          "type": "item",
-          "name": "wiki:raw_silver"
-        }
-      ]
-    }
-  ]
+    ]
 }
 ```
 
@@ -109,29 +109,29 @@ import { world, EquipmentSlot } from "@minecraft/server";
 const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 
 // Register a custom component before the world is loaded
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-  blockTypeRegistry.registerCustomComponent("wiki:silver_ore_xp_reward", {
-    onPlayerDestroy({ block, dimension, player }) {
-      // Check the tool in the player's hand
-      const equippable = player?.getComponent("minecraft:equippable");
-      if (!equippable) return; // Exit if the player or its equipment are undefined
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent("wiki:silver_ore_xp_reward", {
+        onPlayerDestroy({ block, dimension, player }) {
+            // Check the tool in the player's hand
+            const equippable = player?.getComponent("minecraft:equippable");
+            if (!equippable) return; // Exit if the player or its equipment are undefined
 
-      const itemStack = equippable.getEquipment(EquipmentSlot.Mainhand);
-      if (itemStack?.typeId !== "minecraft:iron_pickaxe") return; // Exit if the player isn't holding an iron pickaxe
+            const itemStack = equippable.getEquipment(EquipmentSlot.Mainhand);
+            if (itemStack?.typeId !== "minecraft:iron_pickaxe") return; // Exit if the player isn't holding an iron pickaxe
 
-      // Specify enchantments
-      const enchantable = itemStack.getComponent("minecraft:enchantable");
-      const silkTouch = enchantable?.getEnchantment("silk_touch");
-      if (silkTouch) return; // Exit if the iron pickaxe has the Silk Touch enchantment
+            // Specify enchantments
+            const enchantable = itemStack.getComponent("minecraft:enchantable");
+            const silkTouch = enchantable?.getEnchantment("silk_touch");
+            if (silkTouch) return; // Exit if the iron pickaxe has the Silk Touch enchantment
 
-      // Spawn the XP orbs
-      const xpAmount = randomInt(0, 3); // Number of XP orbs to spawn
+            // Spawn the XP orbs
+            const xpAmount = randomInt(0, 3); // Number of XP orbs to spawn
 
-      for (let i = 0; i < xpAmount; i++) {
-        dimension.spawnEntity("minecraft:xp_orb", block.location);
-      }
-    }
-  });
+            for (let i = 0; i < xpAmount; i++) {
+                dimension.spawnEntity("minecraft:xp_orb", block.location);
+            }
+        },
+    });
 });
 ```
 
@@ -140,27 +140,28 @@ world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
 The following block behavior can be used as a template. Don't forget to set the block's texture using `terrain_texture.json`.
 
 Here you need to do two things:
-- Point to the new loot table with the `minecraft:loot` component.
-- Add our experience reward custom component to the `minecraft:custom_components` array.
+
+-   Point to the new loot table with the `minecraft:loot` component.
+-   Add our experience reward custom component to the `minecraft:custom_components` array.
 
 <CodeHeader>BP/blocks/silver_ore.json</CodeHeader>
 
 ```json
 {
-  "format_version": "1.21.0",
-  "minecraft:block": {
-    "description": {
-      "identifier": "wiki:silver_ore",
-      "menu_category": {
-        "category": "nature",
-        "group": "itemGroup.name.ore"
-      }
-    },
-    "components": {
-      "minecraft:loot": "loot_tables/blocks/silver_ore.json", // Won't be dropped if using Silk Touch.
-      "minecraft:custom_components": ["wiki:silver_ore_xp_reward"]
+    "format_version": "1.21.0",
+    "minecraft:block": {
+        "description": {
+            "identifier": "wiki:silver_ore",
+            "menu_category": {
+                "category": "nature",
+                "group": "itemGroup.name.ore"
+            }
+        },
+        "components": {
+            "minecraft:loot": "loot_tables/blocks/silver_ore.json", // Won't be dropped if using Silk Touch.
+            "minecraft:custom_components": ["wiki:silver_ore_xp_reward"]
+        }
     }
-  }
 }
 ```
 

--- a/docs/blocks/precise-rotation.md
+++ b/docs/blocks/precise-rotation.md
@@ -16,7 +16,7 @@ Check out the [blocks guide](/blocks/blocks-intro) before starting.
 
 This tutorial guides you through making a block with sub-cardinal rotation (e.g. creeper heads and signs), providing examples of a "shell" block with this rotation type.
 
-*Looking for regular rotation? Learn about it [here](/blocks/rotatable-blocks)!*
+_Looking for regular rotation? Learn about it [here](/blocks/rotatable-blocks)!_
 
 ![Custom shell blocks oriented randomly](/assets/images/blocks/precise-rotation/showcase.png)
 
@@ -57,121 +57,121 @@ The following model for a "shell" block can be used as a reference:
 
 ```json
 {
-  "format_version": "1.21.0",
-  "minecraft:geometry": [
-    {
-      "description": {
-        "identifier": "geometry.shell",
-        "texture_width": 16,
-        "texture_height": 16
-      },
-      "bones": [
+    "format_version": "1.21.0",
+    "minecraft:geometry": [
         {
-          "name": "shell",
-          "pivot": [0, 0, 0]
-        },
-        {
-          "name": "up_0",
-          "parent": "shell",
-          "pivot": [0, 0, 0],
-          "cubes": [
-            {
-              "origin": [-3, 0, -3],
-              "size": [6, 3, 6],
-              "uv": {
-                "north": { "uv": [0, 6], "uv_size": [6, 3] },
-                "east": { "uv": [0, 6], "uv_size": [6, 3] },
-                "south": { "uv": [0, 6], "uv_size": [6, 3] },
-                "west": { "uv": [0, 6], "uv_size": [6, 3] },
-                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
-                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
-              }
-            }
-          ]
-        },
-        {
-          "name": "up_22_5",
-          "parent": "shell",
-          "pivot": [0, 0, 0],
-          "rotation": [0, 22.5, 0],
-          "cubes": [
-            {
-              "origin": [-3, 0, -3],
-              "size": [6, 3, 6],
-              "uv": {
-                "north": { "uv": [0, 6], "uv_size": [6, 3] },
-                "east": { "uv": [0, 6], "uv_size": [6, 3] },
-                "south": { "uv": [0, 6], "uv_size": [6, 3] },
-                "west": { "uv": [0, 6], "uv_size": [6, 3] },
-                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
-                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
-              }
-            }
-          ]
-        },
-        {
-          "name": "up_45",
-          "parent": "shell",
-          "pivot": [0, 0, 0],
-          "rotation": [0, 45, 0],
-          "cubes": [
-            {
-              "origin": [-3, 0, -3],
-              "size": [6, 3, 6],
-              "uv": {
-                "north": { "uv": [0, 6], "uv_size": [6, 3] },
-                "east": { "uv": [0, 6], "uv_size": [6, 3] },
-                "south": { "uv": [0, 6], "uv_size": [6, 3] },
-                "west": { "uv": [0, 6], "uv_size": [6, 3] },
-                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
-                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
-              }
-            }
-          ]
-        },
-        {
-          "name": "up_67_5",
-          "parent": "shell",
-          "pivot": [0, 0, 0],
-          "rotation": [0, 67.5, 0],
-          "cubes": [
-            {
-              "origin": [-3, 0, -3],
-              "size": [6, 3, 6],
-              "uv": {
-                "north": { "uv": [0, 6], "uv_size": [6, 3] },
-                "east": { "uv": [0, 6], "uv_size": [6, 3] },
-                "south": { "uv": [0, 6], "uv_size": [6, 3] },
-                "west": { "uv": [0, 6], "uv_size": [6, 3] },
-                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
-                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
-              }
-            }
-          ]
-        },
-        {
-          "name": "side",
-          "parent": "shell",
-          "pivot": [0, 5, 8],
-          "rotation": [90, 0, 0],
-          "cubes": [
-            {
-              "origin": [-3, 5, 8],
-              "size": [6, 3, 6],
-              "uv": {
-                "north": { "uv": [0, 6], "uv_size": [6, 3] },
-                "east": { "uv": [0, 6], "uv_size": [6, 3] },
-                "south": { "uv": [0, 6], "uv_size": [6, 3] },
-                "west": { "uv": [0, 6], "uv_size": [6, 3] },
-                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
-                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
-              }
-            }
-          ]
+            "description": {
+                "identifier": "geometry.shell",
+                "texture_width": 16,
+                "texture_height": 16
+            },
+            "bones": [
+                {
+                    "name": "shell",
+                    "pivot": [0, 0, 0]
+                },
+                {
+                    "name": "up_0",
+                    "parent": "shell",
+                    "pivot": [0, 0, 0],
+                    "cubes": [
+                        {
+                            "origin": [-3, 0, -3],
+                            "size": [6, 3, 6],
+                            "uv": {
+                                "north": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "east": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "south": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "west": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
+                                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "up_22_5",
+                    "parent": "shell",
+                    "pivot": [0, 0, 0],
+                    "rotation": [0, 22.5, 0],
+                    "cubes": [
+                        {
+                            "origin": [-3, 0, -3],
+                            "size": [6, 3, 6],
+                            "uv": {
+                                "north": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "east": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "south": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "west": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
+                                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "up_45",
+                    "parent": "shell",
+                    "pivot": [0, 0, 0],
+                    "rotation": [0, 45, 0],
+                    "cubes": [
+                        {
+                            "origin": [-3, 0, -3],
+                            "size": [6, 3, 6],
+                            "uv": {
+                                "north": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "east": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "south": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "west": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
+                                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "up_67_5",
+                    "parent": "shell",
+                    "pivot": [0, 0, 0],
+                    "rotation": [0, 67.5, 0],
+                    "cubes": [
+                        {
+                            "origin": [-3, 0, -3],
+                            "size": [6, 3, 6],
+                            "uv": {
+                                "north": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "east": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "south": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "west": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
+                                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "side",
+                    "parent": "shell",
+                    "pivot": [0, 5, 8],
+                    "rotation": [90, 0, 0],
+                    "cubes": [
+                        {
+                            "origin": [-3, 5, 8],
+                            "size": [6, 3, 6],
+                            "uv": {
+                                "north": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "east": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "south": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "west": { "uv": [0, 6], "uv_size": [6, 3] },
+                                "up": { "uv": [6, 6], "uv_size": [-6, -6] },
+                                "down": { "uv": [6, 6], "uv_size": [-6, -6] }
+                            }
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }
 ```
 
@@ -185,39 +185,39 @@ Below is the base "shell" block we will be adding advanced rotation to.
 
 ```json
 {
-  "format_version": "1.21.0",
-  "minecraft:block": {
-    "description": {
-      "identifier": "wiki:shell",
-      "menu_category": {
-        "category": "nature"
-      }
-    },
-    "components": {
-      // `up` face collision/selection boxes
-      "minecraft:collision_box": {
-        "origin": [-3, 0, -3],
-        "size": [6, 3, 6]
-      },
-      "minecraft:selection_box": {
-        "origin": [-3, 0, -3],
-        "size": [6, 3, 6]
-      },
-      "minecraft:material_instances": {
-        "*": {
-          "texture": "shell" // Shortname defined in `RP/textures/terrain_texture.json`
+    "format_version": "1.21.0",
+    "minecraft:block": {
+        "description": {
+            "identifier": "wiki:shell",
+            "menu_category": {
+                "category": "nature"
+            }
+        },
+        "components": {
+            // `up` face collision/selection boxes
+            "minecraft:collision_box": {
+                "origin": [-3, 0, -3],
+                "size": [6, 3, 6]
+            },
+            "minecraft:selection_box": {
+                "origin": [-3, 0, -3],
+                "size": [6, 3, 6]
+            },
+            "minecraft:material_instances": {
+                "*": {
+                    "texture": "shell" // Shortname defined in `RP/textures/terrain_texture.json`
+                }
+            },
+            // Prevent block from being placed on `down` face
+            "minecraft:placement_filter": {
+                "conditions": [
+                    {
+                        "allowed_faces": ["up", "side"]
+                    }
+                ]
+            }
         }
-      },
-      // Prevent block from being placed on `down` face
-      "minecraft:placement_filter": {
-        "conditions": [
-          {
-            "allowed_faces": ["up", "side"]
-          }
-        ]
-      }
     }
-  }
 }
 ```
 
@@ -276,13 +276,13 @@ Add the following function to your script:
 ```js
 /** @param {number} playerYRotation */
 function getPreciseRotation(playerYRotation) {
-  // Transform player's head Y rotation to a positive
-  if (playerYRotation < 0) playerYRotation += 360;
-  // How many 16ths of 360 is the head rotation? - rounded
-  const rotation = Math.round(playerYRotation / 22.5);
+    // Transform player's head Y rotation to a positive
+    if (playerYRotation < 0) playerYRotation += 360;
+    // How many 16ths of 360 is the head rotation? - rounded
+    const rotation = Math.round(playerYRotation / 22.5);
 
-  // 0 and 16 represent duplicate rotations (0 degrees and 360 degrees), so 0 is returned if the value of `rotation` is 16
-  return rotation !== 16 ? rotation : 0;
+    // 0 and 16 represent duplicate rotations (0 degrees and 360 degrees), so 0 is returned if the value of `rotation` is 16
+    return rotation !== 16 ? rotation : 0;
 }
 ```
 
@@ -301,23 +301,26 @@ Think of a unique custom component identifier. There can't be duplicate custom c
 <CodeHeader>BP/scripts/shell.js</CodeHeader>
 
 ```js
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-  blockTypeRegistry.registerCustomComponent("wiki:shell_rotation", {
-    beforeOnPlayerPlace(event) {
-      const { player } = event;
-      if (!player) return; // Exit if the player is undefined
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent("wiki:shell_rotation", {
+        beforeOnPlayerPlace(event) {
+            const { player } = event;
+            if (!player) return; // Exit if the player is undefined
 
-      const blockFace = event.permutationToPlace.getState("minecraft:block_face");
-      if (blockFace !== "up") return; // Exit if the block hasn't been placed on the top of another block
+            const blockFace = event.permutationToPlace.getState("minecraft:block_face");
+            if (blockFace !== "up") return; // Exit if the block hasn't been placed on the top of another block
 
-      // Get the rotation using the function from earlier
-      const playerYRotation = player.getRotation().y;
-      const rotation = getPreciseRotation(playerYRotation);
+            // Get the rotation using the function from earlier
+            const playerYRotation = player.getRotation().y;
+            const rotation = getPreciseRotation(playerYRotation);
 
-      // Tell Minecraft to place the correct `wiki:rotation` value
-      event.permutationToPlace = event.permutationToPlace.withState("wiki:rotation", rotation);
-    }
-  });
+            // Tell Minecraft to place the correct `wiki:rotation` value
+            event.permutationToPlace = event.permutationToPlace.withState(
+                "wiki:rotation",
+                rotation
+            );
+        },
+    });
 });
 ```
 
@@ -394,18 +397,18 @@ If you would like your block to have a different collision/selection box when pl
 
 ```json
 {
-  "condition": "q.block_property('minecraft:block_face') != 'up'",
-  "components": {
-    // Add your collision/selection boxes
-    "minecraft:collision_box": {
-      "origin": [-3, 5, 5],
-      "size": [6, 6, 3]
-    },
-    "minecraft:selection_box": {
-      "origin": [-3, 5, 5],
-      "size": [6, 6, 3]
+    "condition": "q.block_property('minecraft:block_face') != 'up'",
+    "components": {
+        // Add your collision/selection boxes
+        "minecraft:collision_box": {
+            "origin": [-3, 5, 5],
+            "size": [6, 6, 3]
+        },
+        "minecraft:selection_box": {
+            "origin": [-3, 5, 5],
+            "size": [6, 6, 3]
+        }
     }
-  }
 }
 ```
 
@@ -419,91 +422,91 @@ Your block JSON and script files after the above steps should look similar to th
 
 ```json
 {
-  "format_version": "1.21.0",
-  "minecraft:block": {
-    "description": {
-      "identifier": "wiki:shell",
-      "menu_category": {
-        "category": "nature"
-      },
-      "traits": {
-        "minecraft:placement_position": {
-          "enabled_states": ["minecraft:block_face"]
-        }
-      },
-      "states": {
-        "wiki:rotation": {
-          "values": { "min": 0, "max": 15 }
-        }
-      }
-    },
-    "components": {
-      "minecraft:collision_box": {
-        "origin": [-3, 0, -3],
-        "size": [6, 3, 6]
-      },
-      "minecraft:selection_box": {
-        "origin": [-3, 0, -3],
-        "size": [6, 3, 6]
-      },
-      "minecraft:geometry": {
-        "identifier": "geometry.shell",
-        "bone_visibility": {
-          "up_0": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation'), 4)",
-          "up_22_5": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 1, 4)",
-          "up_45": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 2, 4)",
-          "up_67_5": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 3, 4)",
-          "side": "q.block_state('minecraft:block_face') != 'up'"
-        }
-      },
-      "minecraft:material_instances": {
-        "*": {
-          "texture": "shell"
-        }
-      },
-      "minecraft:placement_filter": {
-        "conditions": [
-          {
-            "allowed_faces": ["up", "side"]
-          }
+    "format_version": "1.21.0",
+    "minecraft:block": {
+        "description": {
+            "identifier": "wiki:shell",
+            "menu_category": {
+                "category": "nature"
+            },
+            "traits": {
+                "minecraft:placement_position": {
+                    "enabled_states": ["minecraft:block_face"]
+                }
+            },
+            "states": {
+                "wiki:rotation": {
+                    "values": { "min": 0, "max": 15 }
+                }
+            }
+        },
+        "components": {
+            "minecraft:collision_box": {
+                "origin": [-3, 0, -3],
+                "size": [6, 3, 6]
+            },
+            "minecraft:selection_box": {
+                "origin": [-3, 0, -3],
+                "size": [6, 3, 6]
+            },
+            "minecraft:geometry": {
+                "identifier": "geometry.shell",
+                "bone_visibility": {
+                    "up_0": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation'), 4)",
+                    "up_22_5": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 1, 4)",
+                    "up_45": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 2, 4)",
+                    "up_67_5": "q.block_state('minecraft:block_face') == 'up' && !math.mod(q.block_state('wiki:rotation') - 3, 4)",
+                    "side": "q.block_state('minecraft:block_face') != 'up'"
+                }
+            },
+            "minecraft:material_instances": {
+                "*": {
+                    "texture": "shell"
+                }
+            },
+            "minecraft:placement_filter": {
+                "conditions": [
+                    {
+                        "allowed_faces": ["up", "side"]
+                    }
+                ]
+            },
+            "minecraft:custom_components": ["wiki:shell_rotation"]
+        },
+        "permutations": [
+            {
+                "condition": "q.block_state('wiki:rotation') >= 4 || q.block_state('minecraft:block_face') == 'east'",
+                "components": {
+                    "minecraft:transformation": { "rotation": [0, -90, 0] }
+                }
+            },
+            {
+                "condition": "q.block_state('wiki:rotation') >= 8 || q.block_state('minecraft:block_face') == 'south'",
+                "components": {
+                    "minecraft:transformation": { "rotation": [0, 180, 0] }
+                }
+            },
+            {
+                "condition": "q.block_state('wiki:rotation') >= 12 || q.block_state('minecraft:block_face') == 'west'",
+                "components": {
+                    "minecraft:transformation": { "rotation": [0, 90, 0] }
+                }
+            },
+            {
+                "condition": "q.block_state('minecraft:block_face') != 'up'",
+                "components": {
+                    "minecraft:collision_box": {
+                        "origin": [-3, 5, 5],
+                        "size": [6, 6, 3]
+                    },
+                    "minecraft:selection_box": {
+                        "origin": [-3, 5, 5],
+                        "size": [6, 6, 3]
+                    }
+                }
+            }
         ]
-      },
-      "minecraft:custom_components": ["wiki:shell_rotation"]
-    },
-    "permutations": [
-      {
-        "condition": "q.block_state('wiki:rotation') >= 4 || q.block_state('minecraft:block_face') == 'east'",
-        "components": {
-          "minecraft:transformation": { "rotation": [0, -90, 0] }
-        }
-      },
-      {
-        "condition": "q.block_state('wiki:rotation') >= 8 || q.block_state('minecraft:block_face') == 'south'",
-        "components": {
-          "minecraft:transformation": { "rotation": [0, 180, 0] }
-        }
-      },
-      {
-        "condition": "q.block_state('wiki:rotation') >= 12 || q.block_state('minecraft:block_face') == 'west'",
-        "components": {
-          "minecraft:transformation": { "rotation": [0, 90, 0] }
-        }
-      },
-      {
-        "condition": "q.block_state('minecraft:block_face') != 'up'",
-        "components": {
-          "minecraft:collision_box": {
-            "origin": [-3, 5, 5],
-            "size": [6, 6, 3]
-          },
-          "minecraft:selection_box": {
-            "origin": [-3, 5, 5],
-            "size": [6, 6, 3]
-          }
-        }
-      }
-    ]
-  }
+    }
 }
 ```
 
@@ -518,27 +521,30 @@ import { world } from "@minecraft/server";
 
 /** @param {number} playerYRotation */
 function getPreciseRotation(playerYRotation) {
-  if (playerYRotation < 0) playerYRotation += 360;
-  const rotation = Math.round(playerYRotation / 22.5);
+    if (playerYRotation < 0) playerYRotation += 360;
+    const rotation = Math.round(playerYRotation / 22.5);
 
-  return rotation !== 16 ? rotation : 0;
+    return rotation !== 16 ? rotation : 0;
 }
 
-world.beforeEvents.worldInitialize.subscribe(({ blockTypeRegistry }) => {
-  blockTypeRegistry.registerCustomComponent("wiki:shell_rotation", {
-    beforeOnPlayerPlace(event) {
-      const { player } = event;
-      if (!player) return;
+world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
+    blockComponentRegistry.registerCustomComponent("wiki:shell_rotation", {
+        beforeOnPlayerPlace(event) {
+            const { player } = event;
+            if (!player) return;
 
-      const blockFace = event.permutationToPlace.getState("minecraft:block_face");
-      if (blockFace !== "up") return;
+            const blockFace = event.permutationToPlace.getState("minecraft:block_face");
+            if (blockFace !== "up") return;
 
-      const playerYRotation = player.getRotation().y;
-      const rotation = getPreciseRotation(playerYRotation);
+            const playerYRotation = player.getRotation().y;
+            const rotation = getPreciseRotation(playerYRotation);
 
-      event.permutationToPlace = event.permutationToPlace.withState("wiki:rotation", rotation);
-    }
-  });
+            event.permutationToPlace = event.permutationToPlace.withState(
+                "wiki:rotation",
+                rotation
+            );
+        },
+    });
 });
 ```
 

--- a/docs/blocks/precise-rotation.md
+++ b/docs/blocks/precise-rotation.md
@@ -301,26 +301,29 @@ Think of a unique custom component identifier. There can't be duplicate custom c
 <CodeHeader>BP/scripts/shell.js</CodeHeader>
 
 ```js
+/** @type {import("@minecraft/server").BlockCustomComponent} */
+const ShellRotationBlockComponent = {
+    beforeOnPlayerPlace(event) {
+        const { player } = event;
+        if (!player) return; // Exit if the player is undefined
+
+        const blockFace = event.permutationToPlace.getState("minecraft:block_face");
+        if (blockFace !== "up") return; // Exit if the block hasn't been placed on the top of another block
+
+        // Get the rotation using the function from earlier
+        const playerYRotation = player.getRotation().y;
+        const rotation = getPreciseRotation(playerYRotation);
+
+        // Tell Minecraft to place the correct `wiki:rotation` value
+        event.permutationToPlace = event.permutationToPlace.withState("wiki:rotation", rotation);
+    },
+};
+
 world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
-    blockComponentRegistry.registerCustomComponent("wiki:shell_rotation", {
-        beforeOnPlayerPlace(event) {
-            const { player } = event;
-            if (!player) return; // Exit if the player is undefined
-
-            const blockFace = event.permutationToPlace.getState("minecraft:block_face");
-            if (blockFace !== "up") return; // Exit if the block hasn't been placed on the top of another block
-
-            // Get the rotation using the function from earlier
-            const playerYRotation = player.getRotation().y;
-            const rotation = getPreciseRotation(playerYRotation);
-
-            // Tell Minecraft to place the correct `wiki:rotation` value
-            event.permutationToPlace = event.permutationToPlace.withState(
-                "wiki:rotation",
-                rotation
-            );
-        },
-    });
+    blockComponentRegistry.registerCustomComponent(
+        "wiki:shell_rotation",
+        ShellRotationBlockComponent
+    );
 });
 ```
 
@@ -527,24 +530,27 @@ function getPreciseRotation(playerYRotation) {
     return rotation !== 16 ? rotation : 0;
 }
 
+/** @type {import("@minecraft/server").BlockCustomComponent} */
+const ShellRotationBlockComponent = {
+    beforeOnPlayerPlace(event) {
+        const { player } = event;
+        if (!player) return;
+
+        const blockFace = event.permutationToPlace.getState("minecraft:block_face");
+        if (blockFace !== "up") return;
+
+        const playerYRotation = player.getRotation().y;
+        const rotation = getPreciseRotation(playerYRotation);
+
+        event.permutationToPlace = event.permutationToPlace.withState("wiki:rotation", rotation);
+    },
+};
+
 world.beforeEvents.worldInitialize.subscribe(({ blockComponentRegistry }) => {
-    blockComponentRegistry.registerCustomComponent("wiki:shell_rotation", {
-        beforeOnPlayerPlace(event) {
-            const { player } = event;
-            if (!player) return;
-
-            const blockFace = event.permutationToPlace.getState("minecraft:block_face");
-            if (blockFace !== "up") return;
-
-            const playerYRotation = player.getRotation().y;
-            const rotation = getPreciseRotation(playerYRotation);
-
-            event.permutationToPlace = event.permutationToPlace.withState(
-                "wiki:rotation",
-                rotation
-            );
-        },
-    });
+    blockComponentRegistry.registerCustomComponent(
+        "wiki:shell_rotation",
+        ShellRotationBlockComponent
+    );
 });
 ```
 


### PR DESCRIPTION
- Corrected logic error where wiki:stood_on would never be set to false because the custom component was removed
- Combined stepOn and stepOff event listeners into a single custom component
- Script code is now in JavaScript rather than TypeScript
- Replaced generic block identifiers

## Other Changes
- Precise rotation custom component example is now in its own `ShellRotationBlockComponent` variable to be consistent
- Renamed `blockTypeRegistry` to `blockComponentRegistry` to match update to native `WorldInitializeBeforeEvent`
- `RP/blocks.json` format versions are now set to the latest version (1.21.20)