### PR TITLE
Update Blocks and Items Sections to v1.21.40

### DIFF
--- a/docs/blocks/applying-effects.md
+++ b/docs/blocks/applying-effects.md
@@ -13,7 +13,7 @@ mentions:
 description: This tutorial aims to show how to apply status effects to entities as long as these entities stand on the block.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a basic understanding of blocks, including [block states](/blocks/block-states).
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -142,7 +142,7 @@ And done! The code above will trigger the desired status effect as long as the e
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:wither_block",

--- a/docs/blocks/block-components.md
+++ b/docs/blocks/block-components.md
@@ -20,8 +20,8 @@ mentions:
     - QuazChick
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
-Using the latest format version when creating custom blocks provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom blocks, and currently targets format version `1.21.20`.
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
+Using the latest format version when creating custom blocks provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom blocks, and currently targets format version `1.21.40`.
 :::
 :::danger OVERRIDING COMPONENTS
 Only one instance of each component can be active at once. Duplicate components will be overridden by the latest [permutations](/blocks/block-permutations) entry.
@@ -35,7 +35,7 @@ Block components are used to change how your block appears and functions in the 
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:lamp",

--- a/docs/blocks/block-components.md
+++ b/docs/blocks/block-components.md
@@ -519,6 +519,28 @@ A BlockDescriptor is an object that allows you to reference a block (or multiple
 
 See [this](/blocks/block-tags) page for a list of vanilla tags and relevant blocks.
 
+### Redstone Conductivity
+
+Defines a block's ability to conduct redstone power.
+
+_Released from experiment `Upcoming Creator Features` for format versions 1.21.40 and higher._
+
+Type: Object
+
+-   `redstone_conductor`: Boolean
+    -   Determines whether this block conducts direct redstone power.
+-   `allows_wire_to_step_down`: Boolean
+    -   Determines whether redstone wire can travel down the side of this block.
+
+<CodeHeader>minecraft:block > components</CodeHeader>
+
+```json
+"minecraft:redstone_conductivity": {
+    "redstone_conductor": true,
+    "allows_wire_to_step_down": false
+}
+```
+
 ### Selection Box
 
 Defines the area of the block that is selected by the player's cursor. If set to true, default values are used. If set to false, this block is not selectable by the player's cursor. If this component is omitted, default values are used.

--- a/docs/blocks/block-culling.md
+++ b/docs/blocks/block-culling.md
@@ -23,7 +23,7 @@ Culling rules are added in your resource pack's "block_culling" folder and appea
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block_culling_rules": {
         "description": {
             "identifier": "wiki:lamp_culling" // Identifier to be referenced in block JSON geometry component.

--- a/docs/blocks/block-events.md
+++ b/docs/blocks/block-events.md
@@ -21,8 +21,8 @@ mentions:
     - BlazeDrake
 ---
 
-:::tip FORMAT VERSION `1.21.20`
-Using the latest format version when creating custom blocks provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom blocks, and currently targets format version `1.21.20`.
+:::tip FORMAT VERSION `1.21.40`
+Using the latest format version when creating custom blocks provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom blocks, and currently targets format version `1.21.40`.
 :::
 
 ## Registering Custom Components

--- a/docs/blocks/block-items.md
+++ b/docs/blocks/block-items.md
@@ -1,0 +1,77 @@
+---
+title: Block Items
+description: Learn about the items that represent blocks in places like your inventory.
+category: General
+tags:
+    - experimental
+mentions:
+    - QuazChick
+---
+
+## Automatic Block Items
+
+When you hold a block in your hand, what you're really holding is an item that places the block. When a custom block is registered to the game, Minecraft also automatically registers a new item to represent that block in the inventory.
+
+This item uses the menu category and display name defined by the block, but no other components of the auto-block-item can be modified.
+In order to apply other components, such as a 2D icon for your block, you'll need to replace the block's item with your own.
+
+## Replacing Block Items
+
+:::warning FORMAT VERSION 1.21.40 (EXPERIMENTAL)
+Replacing block items requires the `Upcoming Creator Features` experiment to be enabled.
+:::
+
+In order to replace a block item, you will need to create a new item JSON file that has the same identifier as the block.
+
+Your new item will also need the [block placer](/items/item-components#block-placer) component which will allow the item to place the block.
+The block placer component will also give the item the 3D appearance of the block by default, however this can be overriden with the [icon](/items/item-components#icon) component to display a 2D sprite.
+
+### Custom Flower Example
+
+One example of a situation where replacing the block item is necessary is with flower blocks, which should display as an icon in item form rather than being 3D.
+
+<CodeHeader>BP/blocks/daffodil.json</CodeHeader>
+
+```json
+{
+    "format_version": "1.21.40",
+    "minecraft:block": {
+        "description": {
+            "identifier": "wiki:daffodil"
+        },
+        "components": {
+            "minecraft:geometry": "minecraft:geometry.cross",
+            "minecraft:material_instances": {
+                "*": {
+                    "texture": "daffodil",
+                    "render_method": "alpha_test"
+                }
+            }
+        }
+    }
+}
+```
+
+<CodeHeader>BP/items/daffodil.json</CodeHeader>
+
+```json
+{
+    "format_version": "1.21.40",
+    "minecraft:item": {
+        "description": {
+            "identifier": "wiki:daffodil", // Same as the block's ID
+            "menu_category": {
+                "category": "nature",
+                "group": "itemGroup.name.flower"
+            }
+        },
+        "components": {
+            "minecraft:icon": "daffodil",
+            "minecraft:block_placer": {
+                "block": "wiki:daffodil",
+                "replace_block_item": true
+            }
+        }
+    }
+}
+```

--- a/docs/blocks/block-models.md
+++ b/docs/blocks/block-models.md
@@ -141,7 +141,7 @@ If you have textures for your block defined in that file, make sure you migrate 
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:paper_bag",

--- a/docs/blocks/block-permutations.md
+++ b/docs/blocks/block-permutations.md
@@ -8,7 +8,7 @@ mentions:
     - SmokeyStack
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 Before you learn about block permutations, you should be confident with [block states](/blocks/block-states).
 
 When working with block states, ensure that the `min_engine_version` in your pack manifest is `1.20.20` or higher.
@@ -61,7 +61,7 @@ _Released from experiment `Holiday Creator Features` for format versions 1.19.70
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_block",

--- a/docs/blocks/block-sounds.md
+++ b/docs/blocks/block-sounds.md
@@ -16,7 +16,7 @@ This property is used to determine general block sounds, such as the mining soun
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "wiki:custom_log": {
         "sound": "wood" // Define sound here
     }

--- a/docs/blocks/block-states.md
+++ b/docs/blocks/block-states.md
@@ -8,7 +8,7 @@ mentions:
     - SmokeyStack
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 When working with block states, ensure that the `min_engine_version` in your pack manifest is `1.20.20` or higher.
 :::
 
@@ -26,7 +26,7 @@ _Released from experiment `Holiday Creator Features` for format versions 1.19.70
 
 ```json
 {
-  "format_version": "1.21.20",
+  "format_version": "1.21.40",
   "minecraft:block": {
     "description": {
       "identifier": "wiki:custom_block",

--- a/docs/blocks/block-tags.md
+++ b/docs/blocks/block-tags.md
@@ -27,7 +27,7 @@ Block tags can be applied in the same way as items - in the block's `components`
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:tree_stump",
@@ -63,7 +63,7 @@ Example of an item querying a block's tags:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_pickaxe",

--- a/docs/blocks/block-traits.md
+++ b/docs/blocks/block-traits.md
@@ -8,7 +8,7 @@ mentions:
     - SmokeyStack
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 Before you learn about block traits, you should be confident with [block states](/blocks/block-states).
 
 When working with block states, ensure that the `min_engine_version` in your pack manifest is `1.20.20` or higher.
@@ -22,7 +22,7 @@ Block traits can be used to apply vanilla block states (such as direction) to yo
 
 ```json
 {
-  "format_version": "1.21.20",
+  "format_version": "1.21.40",
   "minecraft:block": {
     "description": {
       "identifier": "wiki:custom_slab",

--- a/docs/blocks/blocks-intro.md
+++ b/docs/blocks/blocks-intro.md
@@ -26,7 +26,7 @@ mentions:
     - QuazChick
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This page discusses basic block features. You can learn more about other block components [here](/blocks/block-components).
 :::
 :::danger NOTE
@@ -49,7 +49,7 @@ Below is the **minimum** behavior-side code to get a custom block into the creat
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_block",
@@ -82,7 +82,7 @@ Let's configure our own functionality!
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_block",
@@ -134,7 +134,7 @@ If you'd like to apply a custom model, the [geometry](/blocks/block-components#g
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "wiki:custom_block": {
         "textures": "custom_block", // This texture shortname should be defined in `terrain_texture.json`, as shown below
         "sound": "grass"
@@ -215,7 +215,7 @@ The `blocks.json` entry would look like this:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "wiki:compass_block": {
         "textures": {
             "down": "compass_block_down",

--- a/docs/blocks/custom-crops.md
+++ b/docs/blocks/custom-crops.md
@@ -13,7 +13,7 @@ mentions:
 description: Re-creation of vanilla crops.
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a good understanding of blocks and scripting.
 Check out the [blocks guide](/blocks/blocks-intro), [block states](/blocks/block-states) and [block events](/blocks/block-events) before starting.
 :::
@@ -51,7 +51,7 @@ This code example also includes the base components of our crop which will be ac
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_crop",
@@ -308,7 +308,7 @@ Here is the entire `wiki:custom_crop` file for reference.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_crop",
@@ -547,7 +547,7 @@ Holding a crop block in your hand wouldn't look right, so we place the crop with
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_seeds", // Make sure this is different from your crop's ID.
@@ -574,7 +574,7 @@ Your crop can't only drop seeds! Create a custom food using the template below.
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_food", // Make sure this is different from your crop and seeds' ID.

--- a/docs/blocks/custom-dirt.md
+++ b/docs/blocks/custom-dirt.md
@@ -13,7 +13,7 @@ mentions:
 hidden: true
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.20`
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a good understanding of blocks.
 Check out the [blocks guide](/blocks/blocks-intro), [block states](/blocks/block-states) and [block permutations](/blocks/block-permutations) before starting.
 :::
@@ -36,7 +36,7 @@ Add the `minecraft:is_hoe` or `minecraft:is_shovel` item tags to any custom tool
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_dirt",
@@ -247,7 +247,7 @@ Here is the full `wiki:custom_farmland` json for reference.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_farmland",

--- a/docs/blocks/custom-fluids.md
+++ b/docs/blocks/custom-fluids.md
@@ -14,7 +14,7 @@ description: Re-creation of vanilla fluids.
 hidden: true
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes an advanced understanding of blocks and the execute command.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -59,7 +59,7 @@ Below is the code for a custom fluid. Copy and quick replace `custom_fluid` with
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_fluid",
@@ -257,7 +257,7 @@ To place your custom fluid you need a custom bucket item. Below is the JSON for 
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_fluid_bucket",

--- a/docs/blocks/custom-glass-blocks.md
+++ b/docs/blocks/custom-glass-blocks.md
@@ -11,7 +11,7 @@ mentions:
     - SmokeyStack
 ---
 
-::: tip FORMAT VERSION `1.21.20`
+::: tip FORMAT VERSION `1.21.40`
 This example requires basic knowledge of blocks to understand.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -28,7 +28,7 @@ By the end you should be able to create something like this!
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_glass",
@@ -58,7 +58,7 @@ For the correct face culling to apply to your glass block, textures must be defi
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "wiki:custom_glass": {
         "textures": "custom_glass", // Shortname defined in `RP/textures/terrain_texture.json`
         "sound": "glass"

--- a/docs/blocks/custom-glazed-terracotta.md
+++ b/docs/blocks/custom-glazed-terracotta.md
@@ -9,7 +9,7 @@ mentions:
 description: Re-creation of vanilla glazed terracotta.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a basic understanding of blocks.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -26,7 +26,7 @@ This will create a vanilla-like custom glazed terracotta.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:glazed_terracotta_template",
@@ -127,7 +127,7 @@ Vanilla glazed terracotta rotates certain faces of the block with some specific 
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:geometry": [
         {
             "description": {

--- a/docs/blocks/custom-slabs.md
+++ b/docs/blocks/custom-slabs.md
@@ -12,7 +12,7 @@ hidden: true
 description: Re-creation of vanilla slabs.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a basic understanding of blocks.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -34,7 +34,7 @@ This will create a vanilla-like custom slab.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "components": {
             "minecraft:destructible_by_explosion": {
@@ -125,7 +125,7 @@ This will be the geometry used for your custom slabs.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:geometry": [
         {
             "description": {

--- a/docs/blocks/custom-trapdoors.md
+++ b/docs/blocks/custom-trapdoors.md
@@ -11,7 +11,7 @@ mentions:
     - SmokeyStack
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a good understanding of blocks and basic knowledge of scripting.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -26,7 +26,7 @@ This is the block JSON you'll need for basic trapdoor functionality. It includes
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_trapdoor",
@@ -213,7 +213,7 @@ This will be the geometry used for your custom trapdoors.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:geometry": [
         {
             "description": {

--- a/docs/blocks/custom-trees.md
+++ b/docs/blocks/custom-trees.md
@@ -12,7 +12,7 @@ hidden: true
 description: Re-creation of vanilla trees.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes an advanced understanding of blocks.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -49,7 +49,7 @@ Let's get started. We'll start with the JSON code for the leaf block.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_leaves"
@@ -159,7 +159,7 @@ Let's add our permutation code that will help shape our block's behaviour.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_leaves",
@@ -305,7 +305,7 @@ Let's add our permutation code that will help shape our block's behaviour.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_log",
@@ -421,7 +421,7 @@ Here all components are the same
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_stripped_log",
@@ -499,7 +499,7 @@ For the sapling we will need structures of our tree to make the sapling semi-rea
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_sapling",
@@ -594,7 +594,7 @@ For the sapling we will need structures of our tree to make the sapling semi-rea
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_sapling_placer",
@@ -1032,7 +1032,7 @@ Add sounds to blocks
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "wiki:custom_leaves": {
         "sound": "grass"
     },

--- a/docs/blocks/fake-blocks.md
+++ b/docs/blocks/fake-blocks.md
@@ -111,7 +111,7 @@ Block used to summon the dummy entity right on the block, and as the block is ce
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:align"

--- a/docs/blocks/flipbook-textures.md
+++ b/docs/blocks/flipbook-textures.md
@@ -32,7 +32,7 @@ You can simply apply animated magma's texture to your block by changing `texture
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:flipbook_block",

--- a/docs/blocks/ore-loot-tables.md
+++ b/docs/blocks/ore-loot-tables.md
@@ -17,7 +17,7 @@ mentions:
 description: Create vanilla-like loot system for custom ore.
 ---
 
-:::tip FORMAT VERSION `1.21.20`
+:::tip FORMAT VERSION `1.21.40`
 This tutorial assumes a basic understanding of blocks.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -149,7 +149,7 @@ Here you need to do two things:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:silver_ore",

--- a/docs/blocks/precise-interaction.md
+++ b/docs/blocks/precise-interaction.md
@@ -849,7 +849,7 @@ Don't forget to import your scripts into your pack's entry file!
     "dependencies": [
         {
             "module_name": "@minecraft/server",
-            "version": "1.12.0"
+            "version": "1.15.0"
         }
     ]
 }

--- a/docs/blocks/precise-interaction.md
+++ b/docs/blocks/precise-interaction.md
@@ -11,7 +11,7 @@ mentions:
     - SmokeyStack
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes an advanced understanding of blocks and scripting.
 Check out the [blocks](/blocks/blocks-intro) and [scripting](/scripting/starting-scripts) guides before starting.
 :::
@@ -419,7 +419,7 @@ Interacting with paper will fill the selected slot. Destroying the block release
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:pigeonholes",
@@ -633,7 +633,7 @@ Using our [SelectionBoxes](#selectionboxes-class) class, the player can interact
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:double_flower_pot",

--- a/docs/blocks/precise-rotation.md
+++ b/docs/blocks/precise-rotation.md
@@ -10,7 +10,7 @@ mentions:
 description: This tutorial guides you through making a block with sub-cardinal rotation (e.g. creeper heads and signs), providing examples of a shell block with this rotation type.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes an advanced understanding of blocks and scripting.
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::
@@ -58,7 +58,7 @@ The following model for a "shell" block can be used as a reference:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:geometry": [
         {
             "description": {
@@ -186,7 +186,7 @@ Below is the base "shell" block we will be adding advanced rotation to.
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:shell",
@@ -422,7 +422,7 @@ Your block JSON and script files after the above steps should look similar to th
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:shell",

--- a/docs/blocks/rotatable-blocks.md
+++ b/docs/blocks/rotatable-blocks.md
@@ -11,7 +11,7 @@ mentions:
 description: Create rotatable blocks.
 ---
 
-::: tip FORMAT & MIN ENGINE VERSION `1.21.20`
+::: tip FORMAT & MIN ENGINE VERSION `1.21.40`
 This tutorial assumes a basic understanding of blocks, including [block states](/blocks/block-states) and [block traits](/blocks/block-traits).
 Check out the [blocks guide](/blocks/blocks-intro) before starting.
 :::

--- a/docs/blocks/troubleshooting-blocks.md
+++ b/docs/blocks/troubleshooting-blocks.md
@@ -72,7 +72,7 @@ Dirt like block example:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:dirt_like"
@@ -94,7 +94,7 @@ Log like block example:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:log_like"
@@ -121,7 +121,7 @@ Grass-like block example:
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:custom_grass"
@@ -176,7 +176,7 @@ Solution: Navigate to your block file. Navigate to your `material_instances` com
 
 ```json
 {
-  "format_version": "1.21.20",
+  "format_version": "1.21.40",
   "minecraft:block": {
     ...
     "components": {

--- a/docs/contribute-style.md
+++ b/docs/contribute-style.md
@@ -716,7 +716,7 @@ Example:
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             // Describing an object with components.

--- a/docs/documentation/menu-categories.md
+++ b/docs/documentation/menu-categories.md
@@ -46,7 +46,7 @@ Currently, setting the category to "none" in a custom item (not block) prevents 
 
 ```json
 {
-    "format_version": "1.21.20",
+    "format_version": "1.21.40",
     "minecraft:block": {
         "description": {
             "identifier": "wiki:balsa_wood",
@@ -65,7 +65,7 @@ Currently, setting the category to "none" in a custom item (not block) prevents 
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:dagger",

--- a/docs/entities/npc-dialogues.md
+++ b/docs/entities/npc-dialogues.md
@@ -295,7 +295,7 @@ Lastly, create an item that will open the dialogue when right-clicked/interacted
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:teleport_menu",

--- a/docs/guide/custom-item.md
+++ b/docs/guide/custom-item.md
@@ -88,7 +88,7 @@ We will create a file `BP/items/ectoplasm.json`. Here is the the basic layout of
 
 ```json
 {
-	"format_version": "1.21.10",
+	"format_version": "1.21.40",
 	"minecraft:item": {
 		"description": { ... },
 		"components": { ... }
@@ -97,7 +97,7 @@ We will create a file `BP/items/ectoplasm.json`. Here is the the basic layout of
 ```
 
 Most files in your pack will have 2 top level definitions, `"format_version"` and `"minecraft:<file_type>"`.
-The format version defines which version of the Add-on system Minecraft will use to read this file. For our item, we will be using `1.21.10` to allow us to use the newest features. For more information on format versions you can check [here](/guide/format-version).
+The format version defines which version of the Add-on system Minecraft will use to read this file. For our item, we will be using `1.21.40` to allow us to use the newest features. For more information on format versions you can check [here](/guide/format-version).
 
 The second definitions defines what kind of file this is. In our case, as this is an item definition, it is `minecraft:item`. Under this is where we will put all our information. This will always contain a `description` key.
 
@@ -134,7 +134,7 @@ With that, we have now fully defined our item's behavior. This is what your file
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:ectoplasm",
@@ -267,7 +267,7 @@ Your folder structure should look like this:
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:ectoplasm",

--- a/docs/items/custom-armor.md
+++ b/docs/items/custom-armor.md
@@ -31,7 +31,7 @@ Create a chest piece:
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_chest",
@@ -158,7 +158,7 @@ So while the chest piece alone is great, you probably want a whole set, so from 
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_leggings",
@@ -254,7 +254,7 @@ This is just like the chest piece, just we change some of the categories and slo
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_helm",
@@ -348,7 +348,7 @@ You already know the pattern so lets make the item and attachable json files.
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_boots",

--- a/docs/items/custom-weapon.md
+++ b/docs/items/custom-weapon.md
@@ -27,7 +27,7 @@ Like with the other item tutorials we will start by making a simple custom sword
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_sword",
@@ -144,7 +144,7 @@ You should probably make a recipe for it, which is covered in previous chapters,
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:recipe_shaped": {
         "description": {
             "identifier": "wiki:my_sword"

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -262,6 +262,45 @@ Max cannot be greater than min
 }
 ```
 
+### Durability Sensor
+
+Enables an item to emit effects when it receives damage.
+
+Type: Object
+
+-   `durability_thresholds`: Array
+    -   Items define both the durability thresholds, and the effects emitted when each threshold is met.
+    -   When multiple thresholds are met, only the threshold with the lowest durability after applying the damage is considered.
+
+#### Durability Threshold
+
+Type: Object
+
+-   `durability`: Integer
+    -   The effects are emitted when the item durability value is less than or equal to this value.
+-   `particle_type`: String
+    -   Particle effect to emit when the threshold is met.
+-   `sound_event`: String
+    -   Sound effect to emit when the threshold is met.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:durability_sensor": {
+    "durability_thresholds": [
+        {
+            "durability": 100,
+            "particle_type": "minecraft:explosion_manual",
+            "sound_event": "blast"
+        },
+        {
+            "durability": 5,
+            "sound_event": "raid.horn"
+        }
+    ]
+}
+```
+
 ### Enchantable
 
 Determines what enchantments can be applied to the item. Not all enchantments will have an effect on all item components.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -613,6 +613,27 @@ Type: Object
 }
 ```
 
+### Rarity
+
+Represents how difficult the item is to obtain by changing the color of its name text.
+This component will be overridden and have no effect if the `minecraft:hover_text_color` is also applied.
+
+An item's rarity value will be upgraded to `rare` if enchanted, or `epic` if its base rarity is already `rare`.
+An `epic` rarity item will remain unchanged when enchanted.
+
+Type: String
+
+-   `common` results in a white name.
+-   `uncommon` results in a yellow name.
+-   `rare` results in an aqua name.
+-   `epic` results in a light purple name.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:rarity": "rare"
+```
+
 ### Record
 
 The record item component allows the item to play a sound when used in a jukebox.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -155,6 +155,23 @@ Type: Int
 }
 ```
 
+### Damage Absorption
+
+Causes the item to absorb damage that would otherwise be dealt to its wearer. For this to happen, the item needs to have the durability component and be equipped in an armor slot.
+
+Type: Object
+
+-   `absorbable_causes`: Array
+    -   List of damage causes (such as `entity_attack` and `magma`) that can be absorbed by the item.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:damage_absorption": {
+	"absorbable_causes": ["all"]
+}
+```
+
 ### Digger
 
 Determine how quickly an item can dig specific blocks.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -846,7 +846,7 @@ Type: Object
     "max_launch_power": 1.0,
     "min_draw_duration": 0.0,
     "scale_power_by_draw_duration": false
-    }
+}
 ```
 
 ### Use Animation

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -793,6 +793,47 @@ Determines if the same item with different aux values can stack. Additionally, d
 }
 ```
 
+### Storage Item
+
+Allows the item to act as a container and store other items.
+The item must have a max stack size of 1 for this component to function.
+
+_Released from experiment `Bundles` for format versions 1.21.40 and higher._
+
+Type: Object
+
+-   `allow_nesed_storage_items`: Boolean
+    -   Determines whether other storage items can be placed into the container.
+-   `allowed_items`: Array
+    -   Defines the items that are exclusively allowed in the container.
+    -   If empty all items are allowed in the container.
+-   `banned_items`: Array
+    -   Defines the items that are not allowed in the container.
+-   `max_slots`: Integer (1-64)
+    -   Defines the number of slots in the container.
+-   `max_weight_limit`: Integer
+    -   Defines the maximum allowed total weight of all items in the container.
+        -   To calculate the weight of an item, divide 64 by its max stack size.
+        -   Items that stack to 64 weigh 1 each, those that stack to 16 weigh 4 each and unstackable items weigh 64.
+-   `weight_in_storage_item`: Integer (0-64)
+    -   Defines the additional weight the item adds when inside another storage item.
+        -   A value of 0 means that this item is not allowed inside another storage item.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:storage_item": {
+    "max_slots": 64,
+    "max_weight_limit": 64,
+    "weight_in_storage_item": 4,
+    "allow_nested_storage_items": true,
+    "banned_items": [
+        "minecraft:shulker_box",
+        "minecraft:undyed_shulker_box"
+    ]
+}
+```
+
 ### Tags
 
 The `tags` component determines which tags are attached to an item.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -8,8 +8,8 @@ mentions:
     - QuazChick
 ---
 
-:::tip FORMAT & MIN ENGINE VERSION `1.21.10`
-Using the latest format version when creating custom items provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom items, and currently targets format version `1.21.10`.
+:::tip FORMAT & MIN ENGINE VERSION `1.21.40`
+Using the latest format version when creating custom items provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom items, and currently targets format version `1.21.40`.
 :::
 
 ## Applying Components
@@ -20,7 +20,7 @@ Item components are used to change how your item appears and functions in the wo
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_item",

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -318,6 +318,23 @@ Type: Object
 }
 ```
 
+### Dyeable
+
+Allows the item to be dyed by cauldron water. Once dyed, the item will display the `dyed` texture defined in the `minecraft:icon` component rather than `default`.
+
+Type: Object
+
+-   `default_color`: String
+    -   Optional color to use by default before the player has dyed the item.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:dyeable": {
+	"default_color": "#ffffff"
+}
+```
+
 ### Enchantable
 
 Determines what enchantments can be applied to the item. Not all enchantments will have an effect on all item components.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -547,9 +547,12 @@ Determines the icon to represent the item in the UI and elsewhere. Released from
 
 Type: Object
 
--   `textures`: Object - This map contains the different textures that can be used for the item's icon. `Default` will contain the actual icon texture. Armor trim textures and palettes can be specified here as well. The icon textures are the keys from the `resource_pack/textures/item_texture.json -> texture_data` object associated with the texture file.
+-   `textures`: Object - This map contains the different textures that can be used for the item's icon. `default` will contain the actual icon texture. Armor trim textures and palettes can be specified here as well. The icon textures are the keys from the `resource_pack/textures/item_texture.json -> texture_data` object associated with the texture file.
     -   `default`: String
         -   The actual icon used for items
+    -   `dyed`: String
+        -   The icon used after the item is dyed in a cauldron.
+        -   This can only be displayed if the item has the `minecraft:dyeable` component.
     -   `icon_trim`: String
         -   The icon overlay for when your item has a trim on it.
         -   `icon_trim` implicitly falls back to the type of slot in the `minecraft:wearable` component. Currently, the icon will only overlay if the shortname matches the item’s identifier. Whether this is a bug or feature is unknown yet.

--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -81,6 +81,27 @@ Type: Object
 }
 ```
 
+### Bundle Interaction
+
+Enables the bundle interface and functionality on the item.
+The item must have the `minecraft:storage_item` component for this component to function.
+
+_Released from experiment `Bundles` for format versions 1.21.40 and higher._
+
+Type: Object
+
+-   `num_viewable_slots`: Integer (1-64)
+    -   Defines the maximum number of item stacks accessible from the top of the bundle.
+    -   Slots are accessed in rows filling from the bottom of the tooltip from right to left.
+
+<CodeHeader>minecraft:item > components</CodeHeader>
+
+```json
+"minecraft:bundle_interaction": {
+    "num_viewable_slots": 12
+}
+```
+
 ### Can Destroy In Creative
 
 Determines if the item will break blocks in Creative Mode while swinging.

--- a/docs/items/item-events.md
+++ b/docs/items/item-events.md
@@ -9,8 +9,8 @@ mentions:
     - SmokeyStack
 ---
 
-:::tip FORMAT VERSION `1.21.10`
-Using the latest format version when creating custom items provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom items, and currently targets format version `1.21.10`.
+:::tip FORMAT VERSION `1.21.40`
+Using the latest format version when creating custom items provides access to fresh features and improvements. The wiki aims to share up-to-date information about custom items, and currently targets format version `1.21.40`.
 :::
 
 ## Registering Custom Components

--- a/docs/items/item-tags.md
+++ b/docs/items/item-tags.md
@@ -38,7 +38,7 @@ Item tags can be used to ensure that a item meets certain conditions.
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:my_item"

--- a/docs/items/items-intro.md
+++ b/docs/items/items-intro.md
@@ -38,7 +38,7 @@ Below is the **minimum** behavior-side code to get a custom item into the creati
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_item",
@@ -67,7 +67,7 @@ Let's configure our own functionality!
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_item",
@@ -112,7 +112,7 @@ In our item file, we will add the `minecraft:icon` component to apply the textur
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:custom_item",

--- a/docs/items/throwable.md
+++ b/docs/items/throwable.md
@@ -29,7 +29,7 @@ First, you'll want to make the actual item:
 
 ```json
 {
-    "format_version": "1.21.10",
+    "format_version": "1.21.40",
     "minecraft:item": {
         "description": {
             "identifier": "wiki:throwable_item"

--- a/docs/items/troubleshooting-items.md
+++ b/docs/items/troubleshooting-items.md
@@ -10,6 +10,7 @@ mentions:
     - MedicalJewel105
     - TheDoctor15
     - ThomasOrs
+    - QuazChick
 description: Troubleshooting guide to items.
 ---
 
@@ -19,27 +20,18 @@ This page contains troubleshooting information about _items_. You should read ou
 
 ## Start Here
 
-I followed a tutorial or tried to make my own item and something is wrong! Calm down. This page will help debug common issues. Follow the buttons and prompts to learn about possible issues with your item, and tips for fixing.
+> "I followed a tutorial or tried to make my own item and something's wrong!"
 
-## Stable Items
+No need to panic! This page will help debug common issues.
 
-This section contains troubleshooting information for stable items. Remember, you are using the `1.10` format, so you need both an RP file and a BP file for your item! If you only have a BP file, you have become confused between format versions. Please start again [here](#_1-10-vs-1-16-items).
-
-Find the issue you have, then read the prompts.
-
--   [I cannot /give myself my custom item!](#i-cannot-give-myself-my-custom-item)
--   [My textures are missing!](#my-textures-are-missing)
-
-### I cannot /give myself my custom item!
-
-An issue here will be caused by the item file in the BP.
+### Item Doesn't Exist
 
 -   Confirm that your pack is actually applied to your world
 -   Confirm that your item is in the folder `BP/items/`
 -   Confirm that your item is valid, according to [jsonlint](https://jsonlint.com/).
 -   Confirm that your identifier is all lowercase, and looks similar to this: `wiki:my_item`
 
-### My textures are missing!
+### Missing Textures
 
 Navigate to your `item_texture.json` file. Ensure that it is properly named, and in the correct folder. Some examples of wrong names:
 
@@ -56,85 +48,8 @@ Here is an example file to compare against:
     "resource_pack_name": "wiki",
     "texture_name": "atlas.items",
     "texture_data": {
-        "gem": {
-            "textures": "textures/items/gem"
-        }
-    }
-}
-```
-
-Next, navigate to your items RP file. Ensure that it is in the correct folder. Example of incorrect path:
-
--   ⚠️ `item/gem.json`
-
-An example file, to compare against:
-
-<CodeHeader>RP/items/gem.json</CodeHeader>
-
-```json
-{
-    "format_version": "1.10",
-    "minecraft:item": {
-        "description": {
-            "identifier": "wiki:gem",
-            "category": "Nature"
-        },
-        "components": {
-            "minecraft:icon": "gem", //make sure this string matches the string you put in item_texture.json!
-            "minecraft:render_offsets": "tools"
-        }
-    }
-}
-```
-
-If you followed this properly, your item should now have a texture.
-
----
-
-## Experimental Items
-
-This section contains troubleshooting information for experimental items. Remember, you are using the `1.16` format, so there shouldn't be an RP file for your item! If you have both an RP file and a BP file, you have become confused between format versions. Please start again [here](#_1-10-vs-1-16-items).
-
-Find the issue you have, then read the prompts.
-
--   [Start Here](#start-here)
--   [1.10 vs 1.16 Items?](#110-vs-116-items)
-    -   [Continue](#continue)
--   [Stable Items](#stable-items)
-    -   [I cannot /give myself my custom item!](#i-cannot-give-myself-my-custom-item)
-    -   [My textures are missing!](#my-textures-are-missing)
--   [Experimental Items](#experimental-items)
-    -   [I cannot /give myself my custom item!](#i-cannot-give-myself-my-custom-item-1)
-    -   [My Textures Are Missing!](#my-textures-are-missing-1)
-    -   [My item is Huge](#my-item-is-huge)
--   [What now?](#what-now)
-
-### I cannot /give myself my custom item!
-
--   Confirm that your pack is actually applied to your world
--   Confirm that your item is in the folder `BP/items/`
--   Confirm that your item is valid, according to [jsonlint](https://jsonlint.com/).
--   Confirm that your identifier is all lowercase, and looks similar to this: `wiki:my_item`
-
-### My Textures Are Missing!
-
-Navigate to your `item_texture.json` file. Ensure that it is properly named, and in the correct folder. Some examples of wrong names:
-
--   ⚠️ `texture/item_texture.json`
--   ⚠️ `textures/Item_texture.json`
--   ⚠️ `textures/item_textures.json`
-
-Here is an example file to compare against:
-
-<CodeHeader>RP/textures/item_texture.json</CodeHeader>
-
-```json
-{
-    "resource_pack_name": "wiki",
-    "texture_name": "atlas.items",
-    "texture_data": {
-        "gem": {
-            "textures": "textures/items/gem"
+        "your_item_icon": {
+            "textures": "textures/items/your_item_icon"
         }
     }
 }
@@ -146,19 +61,18 @@ Next, navigate to your items BP file. Place the `minecraft:icon` component in yo
 
 ```json
 {
-  "format_version": "1.21.40",
-  "minecraft:item": {
-      "description": {
-          "identifier": "namespace:your_item",
-          "category" : "items" // This line is required
-      },
-      "components": {
-        "minecraft:icon": {
-          "texture": "your_item_name" // Make sure this string matches the string you put in item_texture.json
+    "format_version": "1.21.40",
+    "minecraft:item": {
+        "description": {
+            "identifier": "wiki:your_item",
+            "menu_category": {
+                "category": "items"
+            }
+        },
+        "components": {
+            "minecraft:icon": "your_item_icon" // Make sure this string matches the shortname you put in item_texture.json
         }
-      },
-      "events": {...}
-  }
+    }
 }
 ```
 

--- a/docs/items/troubleshooting-items.md
+++ b/docs/items/troubleshooting-items.md
@@ -146,7 +146,7 @@ Next, navigate to your items BP file. Place the `minecraft:icon` component in yo
 
 ```json
 {
-  "format_version": "1.21.10",
+  "format_version": "1.21.40",
   "minecraft:item": {
       "description": {
           "identifier": "namespace:your_item",


### PR DESCRIPTION
## Blocks
- Updated all examples to format version 1.21.40.
- Added experimental block items documentation.
- Added `minecraft:redstone_conductivity` component.

## Items
- Updated all examples to format version 1.21.40.
- Removed outdated troubleshooting information.
- Added `minecraft:durability_sensor` component.
- Added `minecraft:damage_absorption` component.
- Added `minecraft:dyeable` component.
- Added `minecraft:rarity` component.
- Added `minecraft:storage_item` component.
- Added `minecraft:bundle_interaction` component.