### PR TITLE
Added the bundles group to the list of groups.

### DIFF
--- a/docs/documentation/menu-categories.md
+++ b/docs/documentation/menu-categories.md
@@ -106,6 +106,7 @@ _For use with the `menu_category` parameter, `group`._
 | itemGroup.name.bed                |
 | itemGroup.name.boat               |
 | itemGroup.name.boots              |
+| itemGroup.name.bundles            |
 | itemGroup.name.buttons            |
 | itemGroup.name.candles            |
 | itemGroup.name.chalkboard         |


### PR DESCRIPTION
I tested it and the group name "itemGroup.name.bundles" does group the item in with the bundles. So, I added "bundles" to the list of groups.