### PR TITLE
Updated Commands Section

### DIFF
--- a/docs/commands/block-entities.md
+++ b/docs/commands/block-entities.md
@@ -1,7 +1,7 @@
 ---
 title: MBE - Max's Block Entity
 category: Techniques
-mention:
+mentions:
     - BedrockCommands
     - zheaEvyline
 nav_order: 3

--- a/docs/commands/comparing-scores.md
+++ b/docs/commands/comparing-scores.md
@@ -1,7 +1,7 @@
 ---
 title: Comparing And Retrieving Scores
 category: Scoreboard Systems
-mention:
+mentions:
     - BedrockCommands
     - zheaEvyline
 description: Learn to test for targets of matching scores / targets with the highest or lowest score.

--- a/docs/commands/display-entities.md
+++ b/docs/commands/display-entities.md
@@ -16,7 +16,7 @@ In this page, we will learn how to create block display entities in Minecraft Be
 
 The first person to develop such a technique was [u/Maxed_Out10](https://www.reddit.com/user/Maxed_Out10/), who used only Vanilla commands. His technique offers less flexibility but is much simpler, using armor stands. To check out his method, you may refer to the ["MBE - Max's Block Entity"](/commands/block-entities) page.
 
-Inspired by Max's Block Entity (MBE), command experts @pipi_Spamton, @siratama, and their team from the Japanese Commands community, have devised a new technique for creating block display entities in Minecraft Bedrock which offers more flexibility and customization. This method is based on the same principles as MBE, but instead of armor stands, it effectively uses the bone structure of foxes to render the block displays.
+Inspired by Max's Block Entity (MBE), command experts @pipi_Spamton, @siratama, and their team from the [Japanese Commands Community](https://discord.gg/xFZH6QJfSB), have devised a new technique for creating block display entities in Minecraft Bedrock which offers more flexibility and customization. This method is based on the same principles as MBE, but instead of armor stands, it effectively uses the bone structure of foxes to render the block displays.
 
 In a traditional sense, you may refer to them as block display entities or simply "display entities". However, in recognition of [u/Maxed_Out10](https://www.reddit.com/user/Maxed_Out10/), they are more popularly known as "Fox MBE" (FMBE) in the Bedrock communities.
 

--- a/docs/commands/display-entities.md
+++ b/docs/commands/display-entities.md
@@ -1,7 +1,7 @@
 ---
 title: FMBE - A New Way to Create Display Entities
 category: Techniques
-mention:
+mentions:
     - BedrockCommands
     - zheaEvyline
 nav_order: 4

--- a/docs/commands/look-detection.md
+++ b/docs/commands/look-detection.md
@@ -1,7 +1,7 @@
 ---
 title: Look Detection
 category: Techniques
-mention:
+mentions:
   - BedrockCommands
   - AjaxGb
   - Plagiatus

--- a/docs/commands/movement-detections.md
+++ b/docs/commands/movement-detections.md
@@ -1,7 +1,7 @@
 ---
 title: Movement Detections
 category: Techniques
-mention:
+mentions:
     - BedrockCommands
     - zheaEvyline
 description: These command-techniques allow you to detect certain player/entity 'states' and subsequently execute your desired commands.

--- a/docs/commands/orbital-camera.md
+++ b/docs/commands/orbital-camera.md
@@ -1,7 +1,7 @@
 ---
 title: Orbital Camera
 category: Techniques
-mention:
+mentions:
   - BedrockCommands
   - zheaEvyline
 description: This technique allows you to confine your camera rotations to an orbit around the player, an entity, or position, with the height and radius of the orbit being fully adjustable.

--- a/docs/commands/rearrange-positions.md
+++ b/docs/commands/rearrange-positions.md
@@ -1,7 +1,7 @@
 ---
 title: Multiplayer Position Rearrangement
 category: Functions
-mention:
+mentions:
     - BedrockCommands
     - zheaEvyline
     - jeanmajid

--- a/docs/concepts/rawtext.md
+++ b/docs/concepts/rawtext.md
@@ -1,6 +1,6 @@
 ---
 title: Rawtext
-mention:
+mentions:
   - BedrockCommands
   - GTB3NW
   - SpacebarNinja
@@ -162,7 +162,7 @@ In the example above, it outputs "`%s joined the game`". For a name to appear in
 `%%s` can be used multiple times. They are filled in the order as shown.
 
 ```json
-/tellraw @a {"rawtext":{"translate":"Hello %%s and %%s", "with":["Steve","Alex"]}]}
+/tellraw @a {"rawtext":[{"translate":"Hello %%s and %%s", "with":["Steve","Alex"]}]}
 #Output in chat:
 #    Hello Steve and Alex
 ```
@@ -200,3 +200,11 @@ This structure allows you to display different text to the selected players base
     - Admin
         - When 'role' score of the player equals 3.
 > Note: Score must be a positive integer.
+
+**How It Works:**
+
+- At "`%%%%s`", the first `%%` is left invalid because no argument (either "s" or an integer) is provided. As a result, it cannot display a value from the array.
+- For the second `%%`, the argument "s" is provided, which displays the first slot in the array (a `{score}`).
+- Since there is no space between the first `%%` and the `{score}` (`%%s`), the `{score}` is interpreted as the integer argument for the first `%%`, making it valid.
+- This allows the score to dynamically change the index of the slot to be displayed.
+


### PR DESCRIPTION
- **FMBE:**
  - Linked the Japanese Commands community.
- **Other Command Pages:**
  - Fixed typo in frontmatter: `mention` —> `mentions`

- **Concepts > Rawtext:**
  - Added short explanations for the additional example provided.