### PR TITLE
Update Format Versions list to Vanilla samples 1.21.50

### DIFF
--- a/docs/guide/format-version.md
+++ b/docs/guide/format-version.md
@@ -62,6 +62,8 @@ This section will list the format versions used in the vanilla game, alongside h
     - The '⭐' is the recommended *stable* version.
     - The '🚀' is the recommended *experimental* version, where applicable.
 
+_Last Updated for 1.21.50_
+
 ### Resource Pack
 
 | Resource Pack        | Version  | Count |

--- a/docs/guide/format-version.md
+++ b/docs/guide/format-version.md
@@ -66,45 +66,63 @@ This section will list the format versions used in the vanilla game, alongside h
 
 | Resource Pack        | Version  | Count |
 |----------------------|----------|-------|
-| Entity               | 1.10.0 ⭐ | 82    |
-| Entity               | 1.8.0    | 74    |
-| Animation Controller | 1.10.0 ⭐ | 56    |
-| Animation            | 1.8.0    | 120   |
-| Animation            | 1.10.0 ⭐ | 6     |
-| Attachables          | 1.10.0 ⭐ | 29    |
-| Attachables          | 1.8.0    | 25    |
+| Animation            | 1.10.0 ⭐ | 6    |
+| Animation            | 1.8.0    | 130   |
+| Animation Controller | 1.10.0 ⭐ | 65   |
+| Attachables          | 1.10.0 ⭐ | 30   |
 | Attachables          | 1.10     | 1     |
-| Models               | 1.8.0    | 92    |
-| Models               | 1.12.0   | 19    |
-| Models               | 1.10.0   | 4     |
-| Models               | 1.16.0   | 7     |
-| Particles            | 1.10.0 ⭐ | 131   |
-| Render Controllers   | 1.10.0 ⭐ | 83    |
+| Attachables          | 1.8.0    | 25    |
+| Entity               | 1.10.0 ⭐ | 88   |
+| Entity               | 1.8.0    | 84    |
+| Fogs                 | 1.16.100 | 73    |
+| Models               | 1.16.0   | 6     |
+| Models               | 1.12.0   | 30    |
+| Models               | 1.10.0   | 5     |
+| Models               | 1.8.0    | 91    |
+| Particles            | 1.10.0 ⭐ | 176  |
+| Render Controllers   | 1.10.0 ⭐ | 24   |
+| Render Controllers   | 1.8.0  | 98   |
 
 ### Behavior Pack
 
 | Category    | Version     | Count |
 |-------------|-------------|-------|
-| Entities    | 1.8.0       | 2     |
+| Entities    | 1.21.50 ⭐  | 9    |
+| Entities    | 1.21.40     | 17    |
+| Entities    | 1.21.30     | 1     |
+| Entities    | 1.21.20     | 2     |
+| Entities    | 1.21.10     | 9     |
+| Entities    | 1.21.0      | 28    |
+| Entities    | 1.19.80     | 1     |
+| Entities    | 1.19.60     | 1     |
+| Entities    | 1.19.50     | 1     |
+| Entities    | 1.19.30     | 1     |
+| Entities    | 1.18.20     | 1     |
+| Entities    | 1.18.10     | 3     |
+| Entities    | 1.17.10     | 1     |
 | Entities    | 1.16.210    | 1     |
-| Entities    | 1.13.0      | 7     |
-| Entities    | 1.16.0 ⭐    | 58    |
-| Entities    | 1.16.100    | 3     |
-| Entities    | 1.12.0      | 21    |
-| Entities    | 1.17.20     | 7     |
-| Entities    | 1.17.10     | 4     |
+| Entities    | 1.16.0      | 19    |
+| Entities    | 1.14.0      | 6     |
+| Entities    | 1.13.0      | 2     |
+| Entities    | 1.12.0      | 14    |
 | Entities    | 1.10.0      | 1     |
-| Entities    | 1.14.0      | 1     |
-| Items       | 1.10 ⭐      | 44    |
+| Entities    | 1.8.0       | 2     |
+| Items       | 1.21.30 ⭐  | 17    |
+| Items       | 1.20.50     | 5     |
 | Items       | 1.16.0      | 1     |
 | Items       | 1.16        | 1     |
 | Items       | 1.14        | 1     |
-| Items       | 1.16.100 🚀 | 0     |
-| Items       | 1.19.80     | 0     |
-| Items       | 1.20.40     | 0     |
-| Recipes     | 1.12        | 991   |
-| Recipes     | 1.16 ⭐      | 194   |
-| Recipes     | 1.14        | 2     |
-| Spawn Rules | 1.8.0 ⭐     | 48    |
-| Spawn Rules | 1.17.0      | 1     |
+| Items       | 1.10        | 45    |
+| Recipes     | 1.21.50 ⭐  | 13   |
+| Recipes     | 1.21.40     | 4     |
+| Recipes     | 1.21.30     | 2     |
+| Recipes     | 1.20.60     | 3     |
+| Recipes     | 1.20.30     | 19    |
+| Recipes     | 1.20.10     | 1315  |
+| Recipes     | 1.16        | 139   |
+| Recipes     | 1.12        | 67    |
+| Spawn Rules | 1.17.0 ⭐   | 1     |
 | Spawn Rules | 1.11.0      | 1     |
+| Spawn Rules | 1.8.0       | 51    |
+
+


### PR DESCRIPTION
## Summary
- Updates the list of format versions per asset type to the latest sample packs 1.21.50.
- Re-orders the table to be newest version first
