### PR TITLE
Implementation of a Protocols page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,10 @@ export default defineConfigWithTheme<ThemeConfig>({
 
     navigation: [
       {
+        text: "Protocol Docs",
+        link: "/protocols/index",
+      },
+      {
         text: "Discord",
         link: "/discord",
       },

--- a/docs/.vitepress/sidebar/index.ts
+++ b/docs/.vitepress/sidebar/index.ts
@@ -11,11 +11,12 @@ export default generateSidebar();
 
 function generateSidebar() {
   const sidebar: Sidebar = {
-    links: [],
-    sections: [],
+    default: { links: [], sections: [] },
+    protocols: { links: [], sections: [] },
   };
 
-  resolveLinks(sidebar);
+  resolveLinks(sidebar.default);
+  resolveLinks(sidebar.protocols);
   resolveSections(sidebar);
 
   return sidebar;

--- a/docs/.vitepress/sidebar/links.ts
+++ b/docs/.vitepress/sidebar/links.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, statSync } from "fs";
 import matter, { GrayMatterFile } from "gray-matter";
 import { basename, join, relative } from "path";
 
-import { Sidebar, SidebarSection } from "../theme";
+import { SidebarItem, SidebarSection } from "../theme";
 import tags from "../tags";
 import sort from "./sort";
 
@@ -12,7 +12,7 @@ function formatLink(path: string) {
   return "/" + path.split(/\\|\//g).join("/").replace(".md", "");
 }
 
-export function resolveLinks(context: Sidebar | SidebarSection, dir: string = docsDirectory) {
+export function resolveLinks(context: SidebarItem | SidebarSection, dir: string = docsDirectory) {
   const isInSection = "categories" in context;
   const entries = readdirSync(dir);
 

--- a/docs/.vitepress/sidebar/sections.ts
+++ b/docs/.vitepress/sidebar/sections.ts
@@ -36,11 +36,11 @@ export function resolveSections(sidebar: Sidebar) {
       resolveCategories(section);
       resolveLinks(section, joinedPath);
 
-      sidebar.sections.push(section);
+      sidebar[sectionFrontmatter.data.page || "default"].sections.push(section);
     }
   }
 
-  sort(sidebar.sections);
+  Object.entries(sidebar).forEach((item) => sort(item[1].sections));
 }
 
 export default function validateSection(id: string, { data }: GrayMatterFile<string>) {

--- a/docs/.vitepress/theme/components/navigation/Sidebar.vue
+++ b/docs/.vitepress/theme/components/navigation/Sidebar.vue
@@ -9,7 +9,16 @@ import SidebarSection from "./SidebarSection.vue";
 import SidebarLink from "./SidebarLink.vue";
 
 const { page, theme } = useData();
-const { links, sections } = theme.value.sidebar;
+
+const sidebar = computed(() => page.value.frontmatter.page || "default");
+
+let links = theme.value.sidebar[sidebar.value].links;
+let sections = theme.value.sidebar[sidebar.value].sections;
+
+watch(sidebar, (sidebarPage) => {
+  links = theme.value.sidebar[sidebarPage].links;
+  sections = theme.value.sidebar[sidebarPage].sections;
+});
 
 const isMobile = useIsMobile();
 
@@ -36,13 +45,8 @@ function toggleSection(id: string) {
       </template>
       <SidebarLink v-for="link in links" :key="link.link" v-bind="link" />
     </ul>
-    <SidebarSection
-      v-for="section in sections"
-      :key="section.id"
-      v-bind="section"
-      :open="openSection === section.id || activeSection === section.id"
-      @click="() => toggleSection(section.id)"
-    />
+    <SidebarSection v-for="section in sections" :key="section.id" v-bind="section"
+      :open="openSection === section.id || activeSection === section.id" @click="() => toggleSection(section.id)" />
   </div>
 </template>
 
@@ -67,8 +71,8 @@ function toggleSection(id: string) {
     list-style: none;
   }
 
-  & > ul,
-  &__section > ul {
+  &>ul,
+  &__section>ul {
     margin: 0.3em;
     border-bottom: var(--border);
   }

--- a/docs/.vitepress/theme/types.ts
+++ b/docs/.vitepress/theme/types.ts
@@ -19,6 +19,10 @@ export interface NavigationItem {
 }
 
 export interface Sidebar {
+  [path: string]: SidebarItem;
+}
+
+export interface SidebarItem {
   links: SidebarLink[];
   sections: SidebarSection[];
 }

--- a/docs/protocols/bedrock.md
+++ b/docs/protocols/bedrock.md
@@ -1,6 +1,6 @@
 ---
 title: Bedrock Protocol
-category: Protocols
+category: MCBE Protocol
 mentions:
     - theaddonn
     - bedrock-crustaceans
@@ -10,7 +10,7 @@ description: Bedrock Game protocol.
 ## Datatypes
 
 | Type                              | Size | Notes                                                        |
-|-----------------------------------|------|--------------------------------------------------------------|
+| --------------------------------- | ---- | ------------------------------------------------------------ |
 | i8 (byte)                         | 1    |                                                              |
 | u8 (unsigned byte)                | 1    |                                                              |
 | i16 (short)                       | 2    | Most often encoded as Little Endian, Sometimes as Big Endian |
@@ -29,11 +29,12 @@ description: Bedrock Game protocol.
 ## Encodings
 
 The Bedrock Protocol can use multiple different Encodings for integers, such as
-- Little Endian
-- Big Endian
-- Variable Length Integer (VarInts)
 
-These change how integers are written and read, both Little Endian and Big Endian are just Endianness. 
+-   Little Endian
+-   Big Endian
+-   Variable Length Integer (VarInts)
+
+These change how integers are written and read, both Little Endian and Big Endian are just Endianness.
 They basically determine the order in which bytes are read and interpreted, more can be read about them [here, on wikipedia](https://en.wikipedia.org/wiki/Endianness).
 
 On the other hand, VarInts are an encoding scheme used to represent integers of varying sizes using a minimal number of bytes.
@@ -48,11 +49,12 @@ It contains metadata about the packet, such as its length, type, and information
 The header is encoded into a compact format that reduces bandwidth usage by using variable-length integers for certain fields.
 
 The GamePacket header is composed of:
-- Gamepacket Length (varint u32), the total size of the packet, including the header and payload
-- GamePacket Header (14 bits encoded as varint u32), the header contains:
-    - Gamepacket ID (10 bits), identifies the specific Gamepacket type
-    - SubClient Sender ID (2 bits), identifies the sender client in multi-client scenarios
-    - SubClient Target ID (2 bits), identifies the target client in multi-client scenarios
+
+-   Gamepacket Length (varint u32), the total size of the packet, including the header and payload
+-   GamePacket Header (14 bits encoded as varint u32), the header contains:
+    -   Gamepacket ID (10 bits), identifies the specific Gamepacket type
+    -   SubClient Sender ID (2 bits), identifies the sender client in multi-client scenarios
+    -   SubClient Target ID (2 bits), identifies the target client in multi-client scenarios
 
 The Gamepacket ID is a maximum of 10 bits, which means that there are up to 2^10 (1024) possible gamepacket IDs.
 But IDs 200 through 299 are used for spin-offs, so they are free to use for custom packets etc.
@@ -68,16 +70,17 @@ The primary goal of compression is to minimize the data size while ensuring that
 
 Bedrock supports multiple compression algorithms that vary in terms of efficiency, speed, and size reduction.
 Each connection can negotiate which algorithm to use, and different compression methods are identified by unique identifiers during communication. The primary algorithms used include:
-- Zlib:
-  A widely-used compression technique that offers configurable levels of compression.
-  This algorithm provides a tradeoff between speed and the level of compression, with higher compression levels yielding smaller output but requiring more computational power.
-  It is effective for compressing large packets.
-- Snappy:
-  A compression algorithm designed for high-speed compression and decompression, focusing more on performance than achieving the highest compression ratios.
-  This algorithm is typically used when speed is critical, especially for smaller data packets.
-- No Compression:
-  In some cases, compression may not be necessary, especially for small data packets/debugging purposes.
-  If the size of a packet is below a certain threshold, compression may be skipped entirely to avoid unnecessary overhead.
+
+-   Zlib:
+    A widely-used compression technique that offers configurable levels of compression.
+    This algorithm provides a tradeoff between speed and the level of compression, with higher compression levels yielding smaller output but requiring more computational power.
+    It is effective for compressing large packets.
+-   Snappy:
+    A compression algorithm designed for high-speed compression and decompression, focusing more on performance than achieving the highest compression ratios.
+    This algorithm is typically used when speed is critical, especially for smaller data packets.
+-   No Compression:
+    In some cases, compression may not be necessary, especially for small data packets/debugging purposes.
+    If the size of a packet is below a certain threshold, compression may be skipped entirely to avoid unnecessary overhead.
 
 (Long story, short... Always use Zlib in production, since it is the best because the others either have problems or are not suited for production)
 
@@ -88,9 +91,10 @@ In Bedrock, the beginning of each packet contains a compression identifier, whic
 This identifier allows the receiving end to understand how to process the incoming data—whether it needs to be decompressed or can be read directly.
 
 The following identifiers are used for the available compression methods:
-- Zlib: 0x00
-- Snappy: 0x01
-- No Compression: 0xFF or 0xFFFF (in [NetworkSettings](#network-settings))
+
+-   Zlib: 0x00
+-   Snappy: 0x01
+-   No Compression: 0xFF or 0xFFFF (in [NetworkSettings](#network-settings))
 
 This compression ID is stored before every gamepacket as am u8 and in the [NetworkSettings](#network-settings), where it is an u16 and defines the default compression method to use.
 
@@ -105,12 +109,14 @@ To be documented...
 ## Login Process
 
 The Bedrock Protocol's login sequence is made up of multiple stages, these being:
-- PreLogin
-- Login
-- Spawn
-- Play
+
+-   PreLogin
+-   Login
+-   Spawn
+-   Play
 
 ### Network Settings Request
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/RequestNetworkSettingsPacket.html)
@@ -121,6 +127,7 @@ The NetworkSettingsRequestPacket has one single field that being the current pro
 This is the first PreLoin packet.
 
 ### Network Settings
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/NetworkSettingsPacket.html)
@@ -128,10 +135,10 @@ This is the first PreLoin packet.
 Used to set up information for the connection, this is where the compression is set and initialized.
 Refer to [Compression](#compression) to find out more about compression here.
 
-
 This is the last PreLoin packet.
 
 ### Login
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/LoginPacket.html)
@@ -146,68 +153,70 @@ If the 2nd and 3rd JWT are missing then the player has not signed in to their Xb
 
 The LoginPacket also contains another JWT encoded as a String, that being the raw token.
 It contains information about the player such as:
-- SelfSignedId
-- ServerAddress = (unresolved url if applicable)
-- ClientRandomId
-- SkinId
-- SkinData
-- SkinImageWidth
-- SkinImageHeight
-- CapeData
-- CapeImageWidth
-- CapeImageHeight
-- SkinResourcePatch
-- SkinGeometryData
-- SkinGeometryDataEngineVersion
-- SkinAnimationData
-- PlayFabId
-- AnimatedImageData = Array of:
-  - Type
-  - Image
-  - ImageWidth
-  - ImageHeight
-  - Frames
-  - AnimationExpression
-- ArmSize
-- SkinColor
-- PersonaPieces = Array of:
-  - PackId
-  - PieceId
-  - IsDefault
-  - PieceType
-  - ProductId
-- PieceTintColors = Array of:
-  - PieceType
-  - Colors = Array of color hexstrings
-- IsEduMode (if edu mode)
-- TenantId (if edu mode)
-- ADRole (if edu mode)
-- IsEditorMode
-- GameVersion
-- DeviceModel
-- DeviceOS = (see enumeration: BuildPlatform)
-- DefaultInputMode = (see enumeration: InputMode)
-- CurrentInputMode = (see enumeration: InputMode)
-- UIProfile = (see enumeration: UIProfile)
-- GuiScale
-- LanguageCode
-- PlatformUserId
-- ThirdPartyName
-- ThirdPartyNameOnly
-- PlatformOnlineId
-- PlatformOfflineId
-- DeviceId
-- TrustedSkin
-- PremiumSkin
-- PersonaSkin
-- OverrideSkin
-- CapeOnClassicSkin
-- CapeId
-- CompatibleWithClientSideChunkGen
+
+-   SelfSignedId
+-   ServerAddress = (unresolved url if applicable)
+-   ClientRandomId
+-   SkinId
+-   SkinData
+-   SkinImageWidth
+-   SkinImageHeight
+-   CapeData
+-   CapeImageWidth
+-   CapeImageHeight
+-   SkinResourcePatch
+-   SkinGeometryData
+-   SkinGeometryDataEngineVersion
+-   SkinAnimationData
+-   PlayFabId
+-   AnimatedImageData = Array of:
+    -   Type
+    -   Image
+    -   ImageWidth
+    -   ImageHeight
+    -   Frames
+    -   AnimationExpression
+-   ArmSize
+-   SkinColor
+-   PersonaPieces = Array of:
+    -   PackId
+    -   PieceId
+    -   IsDefault
+    -   PieceType
+    -   ProductId
+-   PieceTintColors = Array of:
+    -   PieceType
+    -   Colors = Array of color hexstrings
+-   IsEduMode (if edu mode)
+-   TenantId (if edu mode)
+-   ADRole (if edu mode)
+-   IsEditorMode
+-   GameVersion
+-   DeviceModel
+-   DeviceOS = (see enumeration: BuildPlatform)
+-   DefaultInputMode = (see enumeration: InputMode)
+-   CurrentInputMode = (see enumeration: InputMode)
+-   UIProfile = (see enumeration: UIProfile)
+-   GuiScale
+-   LanguageCode
+-   PlatformUserId
+-   ThirdPartyName
+-   ThirdPartyNameOnly
+-   PlatformOnlineId
+-   PlatformOfflineId
+-   DeviceId
+-   TrustedSkin
+-   PremiumSkin
+-   PersonaSkin
+-   OverrideSkin
+-   CapeOnClassicSkin
+-   CapeId
+-   CompatibleWithClientSideChunkGen
 
 This is the first packet for the Login stage.
 
 ### HandshakeServerToClient (Optional)
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ServerToClientHandshakePacket.html)
@@ -217,6 +226,7 @@ Optionally, if it is sent it initializes encryption. Read more about it in the [
 To be documented...
 
 ### HandshakeClientToServer (Optional)
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ClientToServerHandshakePacket.html)
@@ -225,6 +235,7 @@ If the client has initialized Encryption correctly, it responds with this packet
 This packet is completely empty
 
 ### ResourcePacksInfo
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ResourcePacksInfoPacket.html)
@@ -234,6 +245,7 @@ If both the ResourcePacksInfo and ResourcePacksStack are empty, these packets ca
 Then there is only one ClientCacheStatus (Optionally) and ResourcePackClientResponse.
 
 ### ClientCacheStatus (Optional)
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ClientCacheStatusPacket.html)
@@ -242,6 +254,7 @@ If the client supports Caching then it sends this packet, containing one bool in
 Caching support enables certain possibilities in the protocol, read more about them in the [Caching Section](#caching).
 
 ### ResourcePackClientResponse
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ResourcePackClientResponsePacket.html)
@@ -250,6 +263,7 @@ A Reply to the previous ResourcePacksInfoPacket, describing the current status o
 If you want to send any kind of packs, look into the [Sending Resource Packs Section](#sending-resource-packs).
 
 ### ResourcePacksStack
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ResourcePackStackPacket.html)
@@ -257,6 +271,7 @@ If you want to send any kind of packs, look into the [Sending Resource Packs Sec
 Always replied to a ResourcePackClientResponse, until the client has downloaded all packs.
 
 ### ResourcePackClientResponse
+
 (Client -> Server)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ResourcePackClientResponsePacket.html)
@@ -266,6 +281,7 @@ If you want to send any kind of packs, look into the [Sending Resource Packs Sec
 If this packet indicates that the client has downloaded all required packs, the login process may continue.
 
 ### PlayStatus
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ClientToServerHandshakePacket.html)
@@ -276,6 +292,7 @@ If the Login stage was successful, the enum should be set to `LoginSuccess`.
 This is the last packet for the Login stage.
 
 ### StartGamePacket
+
 (Server -> Client)
 
 [Reference in the Official Docs](https://mojang.github.io/bedrock-protocol-docs/html/ClientToServerHandshakePacket.html)
@@ -284,7 +301,7 @@ This is the first packet in the Spawn stage.
 
 ::: tip
 After this packet, you can already send [Inventory Contents](#sending-inventory-contents) or [Chunks](#sending-chunks).
-The client is ready and just waits until you allow it to spawn. 
+The client is ready and just waits until you allow it to spawn.
 :::
 
 ### PlayStatus
@@ -312,7 +329,7 @@ Not everything can be explained in great detail via documentation, that's why lo
 Here is list of Bedrock Protocol implementations
 
 | Name                                                              | Description                                                                  | Language |
-|-------------------------------------------------------------------|------------------------------------------------------------------------------|----------|
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
 | [CloudburstMC/Protocol](https://github.com/CloudburstMC/Protocol) | A protocol library for Minecraft Bedrock Edition                             | Java     |
 | [PMMP/BedrockProtocol](https://github.com/pmmp/BedrockProtocol)   | An implementation of the Minecraft: Bedrock Edition protocol in PHP          | PHP      |
 | [gophertunnel](https://github.com/Sandertv/gophertunnel)          | General purpose library for Minecraft Bedrock Edition software written in Go | Go       |

--- a/docs/protocols/bedrock.md
+++ b/docs/protocols/bedrock.md
@@ -1,5 +1,6 @@
 ---
 title: Bedrock Protocol
+page: protocols
 category: MCBE Protocol
 mentions:
     - theaddonn

--- a/docs/protocols/index.md
+++ b/docs/protocols/index.md
@@ -1,0 +1,29 @@
+---
+title: Protocols of MCBE
+page: protocols
+categories:
+    - title: RakNet Protocol
+      color: blue
+    - title: MCBE Protocol
+      color: green
+    - title: NetherNet Protocol
+      color: red
+mentions:
+    - Misledwater79
+    - bedrock-crustaceans
+description: Detailed docs on all protocols in MCBE.
+---
+
+Welcome! We are so glad you decided to learn Minecraft Bedrock protocol!
+
+Here you can, and will, learn how MCBE protcol works! It all starts with the [RakNet Protocol](/protocols/raknet) & [NetherNet Protocol](/protocols/nethernet). From those, you recieve the [Bedrock Protocol](/protocols/bedrock). This will guide you and give you proper and up-to-date documentation!
+
+## FAQ
+
+### What is the difference between RakNet & NetherNet?
+
+RakNet is the base transport layer, uses UDP, and is open source. NetherNet is a newer transport layer that is only used for Xbox Live sessions, uses WebRTC, and is built by Mojang (Which means it's not open source).
+
+### Is NetherNet replacing RakNet?
+
+Not entirely, NetherNet is not meant to (and can't) replace all of RakNet. It is only used for LAN games, and any friend games (Xbox or In-Game) which both use to use RakNet.

--- a/docs/protocols/nethernet.md
+++ b/docs/protocols/nethernet.md
@@ -1,5 +1,6 @@
 ---
 title: NetherNet Protocol
+page: protocols
 category: NetherNet Protocol
 mentions:
     - theaddonn

--- a/docs/protocols/nethernet.md
+++ b/docs/protocols/nethernet.md
@@ -1,6 +1,6 @@
 ---
 title: NetherNet Protocol
-category: Protocols
+category: NetherNet Protocol
 mentions:
     - theaddonn
     - bedrock-crustaceans
@@ -11,7 +11,7 @@ Minecraft Bedrock uses multiple different protocols under the hood, one of them 
 NetherNet is the main protocol used for xbox live sessions, and is based on web-rtc.
 
 ::: tip
-NetherNet is quite new and not finished, it is not as well known and understood as RakNet is. 
+NetherNet is quite new and not finished, it is not as well known and understood as RakNet is.
 :::
 
 Since we do not know too much about NetherNet, I can only refer to the [documentation made by df-mc](https://github.com/df-mc/nethernet-spec).
@@ -22,7 +22,7 @@ Not everything can be explained in great detail via documentation, that's why lo
 Here is list of NetherNet implementations
 
 | Name                                                                              | Description                                                       | Language |
-|-----------------------------------------------------------------------------------|-------------------------------------------------------------------|----------|
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------- | -------- |
 | [go-nethernet](https://github.com/df-mc/go-nethernet)                             | Go library implementing a basic version of the NetherNet protocol | Go       |
 | [bedrock-crustaceans/nethernet](https://github.com/bedrock-crustaceans/nethernet) | NetherNet implementation in Rust                                  | Rust     |
 

--- a/docs/protocols/raknet.md
+++ b/docs/protocols/raknet.md
@@ -1,6 +1,6 @@
 ---
 title: RakNet Protocol
-category: Protocols
+category: RakNet Protocol
 mentions:
     - ZestiiSpaghett
     - MedicalJewel105
@@ -21,14 +21,14 @@ Bedrock uses the port `19132` (Ipv4, use `19133` for ipv6) as its default RakNet
 
 ### RakNet Notes
 
-- The offline message id will always be: `0x00ffff00fefefefefdfdfdfd12345678` - this series of bytes will be referred to as _Magic_.
-- The offline message id is sent with unconnected messages such as unconnected pings and pongs.
-- The first byte is used to identify the type of the packet.
+-   The offline message id will always be: `0x00ffff00fefefefefdfdfdfd12345678` - this series of bytes will be referred to as _Magic_.
+-   The offline message id is sent with unconnected messages such as unconnected pings and pongs.
+-   The first byte is used to identify the type of the packet.
 
 ### Datatypes
 
 | Type                 | Size | Range           | Notes                                                                         |
-|----------------------|------|-----------------|-------------------------------------------------------------------------------|
+| -------------------- | ---- | --------------- | ----------------------------------------------------------------------------- |
 | u8 (byte)            | 1    | 0-255           | A single Byte                                                                 |
 | i16 (short)          | 2    | -32768 - 32767  | Signed 16-bit integer                                                         |
 | u16 (unsigned short) | 2    | 0 - 65535       | Unsigned 16-bit integer                                                       |
@@ -54,14 +54,12 @@ Bedrock uses the port `19132` (Ipv4, use `19133` for ipv6) as its default RakNet
 -   [Connection Request Accepted](#connection-request-accepted)
 -   [New Incoming Connection](#new-incoming-connection)
 
-
 ### Unconnected Pings
 
 Minecraft Bedrock will send out a message to all listed servers (and the local network) to check if any games are available and retrieve the MOTD from the game.
 These messages are known as unconnected pings and are structured in this format:
 
 `0x01 | client alive time in ms (unsigned long long) | magic | client GUID`
-
 
 ### Unconnected Pongs
 
@@ -77,8 +75,8 @@ Example:
 
 The client doesn't seem to use the gamemode or the numeric value for the gamemode.
 
-
 ### Open Connection Request 1
+
 (Client -> Server)
 
 The client sends this when attempting to join the server
@@ -90,8 +88,8 @@ The null padding seems to be used to discover the maximum packet size the networ
 The client will send this to the server with decreasing null padding,
 until the server responds with a [Open Connection Reply 1](#open-connection-reply-1)
 
-
 ### Open Connection Reply 1
+
 (Server -> Client)
 
 The server responds with this once the client attempts to join
@@ -100,16 +98,16 @@ The server responds with this once the client attempts to join
 
 This is the first half of the handshake between the client and the server.
 
-
 ### Open Connection Request 2
+
 (Client -> Server)
 
 The client responds with this after they receive the open connection reply 1 packet.
 
 `0x07 | magic | Cookie (uint32, if server has security) | Client supports security (Boolean(false), always false for the vanilla client, if server has security) | server Address | MTU Size (Unsigned short) | client GUID (Long)`
 
-
 ### Open Connection Reply 2
+
 (Server -> Client)
 
 This is the last part of the handshake between the client and the server.
@@ -118,24 +116,24 @@ This is the last part of the handshake between the client and the server.
 
 **From here on, all RakNet messages are contained in a [Frame Set Packet](https://wiki.vg/Raknet_Protocol#Frame_Set_Packet).**
 
-
 ### Connection Request
+
 (Client -> Server)
 
 This is the part where the client sends the connection request.
 
 `0x09 | client GUID (Long) | Request timestamp (Long) | Secure (Boolean)`
 
-
 ### Connection Request Accepted
+
 (Server -> Client)
 
 The server sends this packet in response to the incoming connection request.
 
 `0x10 | client Address | System index (Short, unknown what this does. 0 works as a value (Minecraft client sends 47)) | System adresses ([]Address) | Ping time (Long) | Pong Time (Long)`
 
-
 ### New Incoming Connection
+
 (Client -> Server)
 
 Our RakNet connection is now fully successful.
@@ -148,7 +146,6 @@ The next two packets (and the first Minecraft Protocol packet) are all sent toge
 The RakNetProtocol allows for them to be sent separately too, however, servers with a custom raknet implementation might not always handle this case because this never occurs within the vanilla client.
 
 :::
-
 
 ### New Incoming Connection
 
@@ -165,7 +162,6 @@ After having sent this packet,
 you must periodically send a Connected Ping to keep the connection alive.
 The server also sometimes sends a Connected Ping, respond with a Connected Pong.
 
-
 ### Connected Ping
 
 The client sends this packet immediately after/with New Incoming Connection.
@@ -174,7 +170,6 @@ The client/server will respond to this with a Connected Pong.
 
 `0x00 | Time since start (uint64)`
 
-
 ### Connected Pong
 
 The client or server sends this packet after having received a Connected Ping.
@@ -182,15 +177,13 @@ This packet should be sent as unreliable.
 
 `0x00 | Time since start client (uint64) | Time since start server (uint64)`
 
-
-
 ## Implementations
 
 Not everything can be explained in great detail via documentation, that's why looking at existing implementations is very helpful.
 Here is list of RakNet Protocol implementations
 
 | Name                                                                                            | Description                                                                         | Language               |
-|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
+| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------- |
 | [RakNet (Official)](https://github.com/facebookarchive/RakNet)                                  | RakNet is a cross platform, open source, C++ networking engine for game programmers | C++                    |
 | [bedrock-crustaceans/raknet](https://github.com/bedrock-crustaceans/raknet)                     | RakNet implementation in Rust                                                       | Rust                   |
 | [NetrexMC/RakNet](https://github.com/NetrexMC/RakNet)                                           | RakNet implementation in Rust                                                       | Rust                   |

--- a/docs/protocols/raknet.md
+++ b/docs/protocols/raknet.md
@@ -1,5 +1,6 @@
 ---
 title: RakNet Protocol
+page: protocols
 category: RakNet Protocol
 mentions:
     - ZestiiSpaghett

--- a/docs/servers/index.md
+++ b/docs/servers/index.md
@@ -1,8 +1,3 @@
 ---
 title: Servers
-categories:
-    - title: Software
-      color: red
-    - title: Protocols
-      color: green
 ---

--- a/docs/servers/server-software.md
+++ b/docs/servers/server-software.md
@@ -160,4 +160,4 @@ So if you know a server software that is missing here or know that a server soft
 
 ## Further Information
 
-If you want to create your own server software/understand how they work, take a look into the [MCBE Protocol](./bedrock) and [RakNet](./raknet) documentation.
+If you want to create your own server software/understand how they work, take a look into the [MCBE Protocol](../protocols/bedrock) and [RakNet](../protocols/raknet) documentation.

--- a/docs/servers/server-software.md
+++ b/docs/servers/server-software.md
@@ -1,6 +1,5 @@
 ---
 title: Bedrock Server Software
-category: Software
 mentions:
     - SirLich
     - DevGod6969
@@ -34,18 +33,20 @@ Alongside the Vanilla BDS offering, many community projects exist, in a variety 
 These other projects get separated into Custom Server Software (Custom) and BDS-Based.
 
 Types of Server Software:
-- Custom Server Software = Server Software that is build from completely scratch.
-- BDS-Based = Server Software that uses BDS as a base and modifies it.
+
+-   Custom Server Software = Server Software that is build from completely scratch.
+-   BDS-Based = Server Software that uses BDS as a base and modifies it.
 
 You might notice that there is a lot of Custom Server Software, compared to BDS-Based ones.
 This has plenty of reasons, the biggest being:
-- We did not have an official Server Software for a long time, the first Release of BDS was on August 28, 2018... about 7 years after the first release for Bedrock Edition in 2011
-- The Symbols (also referred to as Mappings) have first been stripped to reduce the amount of information contained and finally been removed from the game in 1.21.10, due to which a lot of BDS-Based software died
+
+-   We did not have an official Server Software for a long time, the first Release of BDS was on August 28, 2018... about 7 years after the first release for Bedrock Edition in 2011
+-   The Symbols (also referred to as Mappings) have first been stripped to reduce the amount of information contained and finally been removed from the game in 1.21.10, due to which a lot of BDS-Based software died
 
 ## Active Software
 
 | Name                                                                            | Description                                                                                      | Language                     | Type      |
-|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|------------------------------|-----------|
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------- | --------- |
 | [Endstone](https://github.com/EndstoneMC/endstone)                              | A High-level Plugin API for Modding Bedrock Dedicated Servers, in both Python and C++.           | C++, Python                  | BDS-Based |
 | [LeviLamina](https://github.com/LiteLDev/LeviLamina)                            | A lightweight, modular and versatile mod loader for Minecraft Bedrock Edition.                   | C++                          | BDS-Based |
 | [RAstra](https://github.com/bedrock-crustaceans/RAstra)                         | Modern Minecraft Bedrock Server Software written in Rust.                                        | Rust, JavaScript, TypeScript | Custom    |
@@ -64,7 +65,7 @@ This has plenty of reasons, the biggest being:
 ## Discontinued Software
 
 | Name                                                                                   | Description                                                                                                                       | Language   | Type      |
-|----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|------------|-----------|
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------- | --------- |
 | [AllayBE](https://github.com/AllayBE/AllayBE)                                          |                                                                                                                                   | C++        | Custom    |
 | [BedrockPowder](https://github.com/BedrockPowder/BedrockPowder)                        | A Bedrock Edition Server software written on C++                                                                                  | C++        | Custom    |
 | [Cenisys](https://github.com/iTXTech/Cenisys)                                          | Clean, concurrent, coroutine-enabled Minecraft server written in C++.                                                             | C++        | Custom    |
@@ -154,7 +155,7 @@ This has plenty of reasons, the biggest being:
 
 ::: tip
 Since new software gets created all the time, and old software becomes unmaintained it is always important to update this list.
-So if you know a server software that is missing here or know that a server software is no longer maintained, then please update this list and create a PR. 
+So if you know a server software that is missing here or know that a server software is no longer maintained, then please update this list and create a PR.
 :::
 
 ## Further Information


### PR DESCRIPTION
Protocol docs are fairly big, of course depending on what all is documented, but with there being 3 protocols I figured it might be best to move this to it's own area as the current sidebar is pretty big and a lot to look at. I implemented a simple addition that allows other pages but you need to add it to `docs/.vitepress/sidebar/index.ts` and then add `page: pagename` to the index markdown doc. Links are also manual as I am not sure why they exist and not sure how to implement something that doesn't exist. I am un-sure why my eslint prettier changed a bunch but doesn't seem to have changed the actual layout.