### PR TITLE
Add NBT Explorer to list of Bedrock Tools Websites

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -15,6 +15,7 @@ mentions:
     - Noruaric
     - JaylyDev
     - zheaEvyline
+    - phoenixr-codes
 description: Useful links for developing add-ons.
 ---
 
@@ -88,6 +89,7 @@ Important links have a ⭐.
 -   [Structure Editor](https://mcbe-essentials.github.io/structure-editor/)
 -   [Trade Table Generator](https://mcbe-essentials.github.io/trade-table-editor/)
 -   [World Packager](https://mcbe-essentials.github.io/world-packager/)
+-   [NBT Explorer](https://phoenixr-codes.github.io/mcnbt/)
 
 ## Documentation
 

--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -84,12 +84,12 @@ Important links have a ⭐.
 -   [.mcpack Generator](https://mcbe-essentials.github.io/instant-pack/)
 -   [Molang Grapher](https://jannisx11.github.io/molang-grapher/)
 -   [Molang Playground](https://bridge-core.github.io/molang-playground/)
+-   [NBT Explorer](https://phoenixr-codes.github.io/mcnbt/)
 -   [Nine Slice Visualiser (UI)](https://minato-mba.github.io/content/9slice.html)
 -   [Selector Generator](https://mcbe-essentials.github.io/selector-generator/)
 -   [Structure Editor](https://mcbe-essentials.github.io/structure-editor/)
 -   [Trade Table Generator](https://mcbe-essentials.github.io/trade-table-editor/)
 -   [World Packager](https://mcbe-essentials.github.io/world-packager/)
--   [NBT Explorer](https://phoenixr-codes.github.io/mcnbt/)
 
 ## Documentation
 


### PR DESCRIPTION
I've crated [NBT Explorer](https://phoenixr-codes.github.io/mcnbt/) a while ago. The NBT editing/viewing software listed under "Software (installed)" must be installed whereas the website can be used without installation and works on mobile devices as well.