### PR TITLE
Correct namespace identifier in hurt animations tutorial 

### DIFF
--- a/docs/visuals/custom-hurt-animations.md
+++ b/docs/visuals/custom-hurt-animations.md
@@ -80,7 +80,7 @@ To call this event add `damage_sensor` to components:
     "triggers": {
         "cause": "all",
         "on_damage": {
-            "event": "nubs:on_hurt_event"
+            "event": "wiki:on_hurt_event"
         }
     }
 }


### PR DESCRIPTION
Correct namespace of damage event from `nubs:on_damage_event` to `wiki:on_damage_event`