### PR TITLE
Remove "ResourcePack Converter (App)"

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -60,7 +60,6 @@ Important links have a ⭐.
 -   [Feature Rule Generator v2 (Paid Version)](https://machine-builder.itch.io/frg-v2)
 -   [NBT Editor](https://www.universalminecrafteditor.com/)
 -   [NBT Studio](https://github.com/tryashtar/nbt-studio)
--   [ResourcePack Converter (App)](https://converter.bedrockhub.io)
 -   [SuitcaseJS (MCPack Compressor)](https://github.com/TBroz15/SuitcaseJS)
 -   [World Converter (Paid)](https://www.universalminecraftconverter.com/download)
 


### PR DESCRIPTION
We moved this project to a discord bot, so the link to the app doesn't exist anymore.