### PR TITLE
Fix: Resolve unescaped callout

### DIFF
--- a/docs/entities/render-controllers.md
+++ b/docs/entities/render-controllers.md
@@ -91,7 +91,7 @@ Render controllers work based on short-names. If you want to use the cow render 
 -   `default` geometry
 -   `default` texture
 -   `default` material
-    :::
+:::
 
 ## Creating custom render controllers
 


### PR DESCRIPTION
- A callout on entities/render-controllers was not escaped, which caused the remainder of the page to be within the callout 
**Preivous**
![image](https://github.com/user-attachments/assets/bc8d7542-dbe5-41c9-9749-eaefdde088d4)
**Now**
![image](https://github.com/user-attachments/assets/03bc14b8-c4f8-48a5-93dd-d36629fcf28b)
