### PR TITLE
Updated references to wiki.vg

### DIFF
--- a/docs/nbt/mcstructure.md
+++ b/docs/nbt/mcstructure.md
@@ -35,7 +35,7 @@ In this case, the file in the `mystructure` folder is the one that "wins," resul
 
 ### File Format
 
-`mcstructure` files are uncompressed [NBT files](https://wiki.vg/NBT#Specification). Like all Bedrock Edition NBT files, they are stored in little-endian format. The tag structure is as follows:
+`mcstructure` files are uncompressed [NBT files](https://minecraft.wiki/w/NBT_format). Like all Bedrock Edition NBT files, they are stored in little-endian format. The tag structure is as follows:
 
 > ![Integer][int] `format_version`: Currently always set to `1`.
 >

--- a/docs/servers/raknet.md
+++ b/docs/servers/raknet.md
@@ -49,7 +49,7 @@ Bedrock uses the port `19132` (Ipv4, use `19133` for ipv6) as its default RakNet
 -   [Open Connection Request 2](#open-connection-request-2)
 -   [Open Connection Reply 2](#open-connection-reply-2)
     (From here on, the RakNet connection is established,
-    and all RakNet messages are contained in a [Frame Set Packet](https://wiki.vg/Raknet_Protocol#Frame_Set_Packet))
+    and all RakNet messages are contained in a [Frame Set Packet](https://minecraft.wiki/w/RakNet#Frame_Set_Packet))
 -   [Connection Request](#connection-request)
 -   [Connection Request Accepted](#connection-request-accepted)
 -   [New Incoming Connection](#new-incoming-connection)
@@ -207,7 +207,7 @@ Here is list of RakNet Protocol implementations
 ::: tip
 If you are interested and want to read more about RakNet here is the documentation for the Bedrock Protocol and RakNet:
 
-[RakNet Protocol Documentation](https://wiki.vg/Raknet_Protocol)
+[RakNet Protocol Documentation](https://minecraft.wiki/w/RakNet)
 [Other RakNet Protocol Documentation](https://github.com/vp817/RakNetProtocolDoc)
 :::
 


### PR DESCRIPTION
This is a small PR to update the references to `wiki.vg` to their appropriate places on the minecraft wiki. This only affects the server and NBT pages.