### PR TITLE
Fix 'typo' in loot-tables.md

### DIFF
--- a/docs/loot/loot-tables.md
+++ b/docs/loot/loot-tables.md
@@ -209,7 +209,7 @@ Loot hierarchies can be formed using loot table entries.
 
 ```json
 "type": "loot_table",
-"name": "loot_tables/custom/example.json"
+"name": "loot_tables/custom/example.json",
 "weight": 1
 ```
 


### PR DESCRIPTION
A `,` was missing the loot-tables.md


![image](https://github.com/user-attachments/assets/4fb9b5e7-1707-4394-a6e2-230ba48e54f4)
