### PR TITLE
More updates of useful links

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -47,7 +47,7 @@ Important links have a ⭐.
 ## Software (installed)
 
 -   ⭐ [Blockbench: A boxy 3D model editor](https://blockbench.net/)
--   ⭐ [bridge. Add-on Editor](https://bridge-core.github.io/)
+-   ⭐ [bridge. Add-on Editor](https://bridge-core.app/)
 -   ⭐ [VSCode Editor](https://code.visualstudio.com/)
 -   ⭐ [Regolith](https://github.com/Bedrock-OSS/regolith)
 -   [Add-on JSON Generator (Paid)](https://kaifireborn.itch.io/add-on-json-generator)
@@ -66,6 +66,7 @@ Important links have a ⭐.
 ## Bedrock Tools Websites
 
 -   ⭐ [Snowstorm Particle Generator](https://jannisx11.github.io/snowstorm/)
+-   ⭐ [mctools.dev](https://mctools.dev/)
 -   ⭐ [Loot Table Generator](https://bedrock-oss.github.io/bedrock-loot-gen/)
 -   [Add-on Obfuscator](https://tools.pixelpoly.co/obfuscator)
 -   [Apply Loot Tables to Structures](https://mcbe-essentials.github.io/structure-editor/loot-tabler)

--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -140,7 +140,7 @@ These packs are published by the open-source community.
 
 ## Add-On Marketplaces & Links
 
--   ⭐ [Minecraft Marketplace](https://www.minecraft.net/en-us/catalog)
+-   ⭐ [Minecraft Marketplace](https://www.minecraft.net/en-us/marketplace)
 -   ⭐ [MCPEDL](http://mcpedl.com/?cookie_check=1)
 -   ⭐ [Bucket of Crabs (Marketplace Joblist)](https://www.bucketofcrabs.net/)
 -   [CubitosMC](https://www.cubitosmc.com/)

--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -96,7 +96,6 @@ Important links have a ⭐.
 -   ⭐ [bedrock.dev](https://bedrock.dev/)
 -   ⭐ [Minecraft Creator Portal](https://docs.microsoft.com/en-us/minecraft/creator/)
 -   ⭐ [Minecraft Community Wiki](https://minecraft.wiki)
--   [Bedrock Texture Pack Template](https://github.com/Brennian/BedrockTexturesTemplate)
 -   [Documentation Graveyard (Removed Components)](https://gist.github.com/destruc7i0n/ea1a6a7f97f0986d9326c58246f96fa3)
 
 ### Getting Started with Your First Add-On
@@ -160,3 +159,4 @@ These packs are published by the open-source community.
 -   [Run Bedrock on Linux](https://github.com/Element-0/ElementZero)
 -   [Skin Pack Generator](https://github.com/MedicalJewel105/bedrock-skin-pack-generator)
 -   [UUID v4 Generator (Online)](https://www.uuidgenerator.net/version4)
+-   [Bedrock Texture Pack Template](https://github.com/Brennian/BedrockTexturesTemplate)

--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -145,7 +145,7 @@ These packs are published by the open-source community.
 -   ⭐ [Bucket of Crabs (Marketplace Joblist)](https://www.bucketofcrabs.net/)
 -   [CubitosMC](https://www.cubitosmc.com/)
 -   [MCDLHub](https://mcdlhub.com/)
--   [Minecraft Marketplace Partners](https://www.playthismap.com/partners)
+-   [Minecraft Marketplace Partners](https://bedrockexplorer.com/partners)
 -   [Minecraft Marketplace Stats](https://mcmarketstats.miste.fr/globalStats/)
 -   [Modbay](https://modbay.org/)
 


### PR DESCRIPTION
Updates the useful links page to include mctools.dev, and update the bridge. link to the current live site instead of a github.io site.

- Adds mctools.dev
- Updates old bridge. editor link
- Updates the Minecraft Marketplace link to avoid a redirect on .net
- Updates Marketplace partners link to the direct bedrock explorer page instead of the playthismap mirror
- Moves the link to an RP testing world template down to other useful links as it has not been updated since 1.17