### PR TITLE
Added support for syntax highlighting on inline code blocks.

### DIFF
--- a/docs/.vitepress/theme/config.ts
+++ b/docs/.vitepress/theme/config.ts
@@ -3,7 +3,29 @@ import taskListsPlugin from "markdown-it-task-lists";
 
 import { ThemeConfig, WikiConfig } from "./types";
 import head, { transformHead } from "./head";
+import * as shiki from "shiki";
 import languages from "./languages";
+
+// Used for inline code block syntax highlighting, this is necessary as by default the custom highlighter used does not import the built-in languages.
+const inlineCodeBlockSyntaxHighlightingLanguages: shiki.LanguageRegistration[] = [];
+for (const language of Object.values(shiki.bundledLanguages)) {
+  const languageRegistration = (await language()).default[0];
+  /**
+   * Allow for using the custom JSON language definition from {@link languages}.
+   */
+  if (languageRegistration.name === "json") {
+    continue;
+  }
+  inlineCodeBlockSyntaxHighlightingLanguages.push(languageRegistration);
+}
+inlineCodeBlockSyntaxHighlightingLanguages.push(...languages);
+const lightTheme = (await shiki.bundledThemes["light-plus"]()).default;
+const darkTheme = (await shiki.bundledThemes["dark-plus"]()).default;
+const highlighter = shiki.createHighlighterCoreSync({
+  engine: shiki.createJavaScriptRegexEngine(),
+  themes: [lightTheme, darkTheme],
+  langs: inlineCodeBlockSyntaxHighlightingLanguages,
+});
 
 const isFastBuild = process.env.FAST_BUILD?.trim() === "true";
 
@@ -79,6 +101,24 @@ export function defineWikiConfig(config: WikiConfig) {
       },
       config(md) {
         md.use(taskListsPlugin, { label: true });
+
+        // 8Crafter's inline code block syntax highlighting plugin.
+        md.renderer.rules.code_inline = (tokens, idx) => {
+          const code = tokens[idx].content;
+          const highlighted = highlighter.codeToHtml(code, {
+            lang: tokens[idx].attrGet("lang") ?? "",
+            themes: { light: lightTheme, dark: darkTheme },
+            structure: "inline",
+            defaultColor: false,
+          });
+          return `${
+            (tokens[idx].attrGet("noLeftCodeBlock") ?? "false") === "true"
+              ? ""
+              : '<code class="shiki">'
+          }${highlighted}${
+            (tokens[idx].attrGet("noRightCodeBlock") ?? "false") === "true" ? "" : "</code>"
+          }`;
+        };
       },
     },
 

--- a/docs/contribute-style.md
+++ b/docs/contribute-style.md
@@ -6,6 +6,7 @@ mentions:
     - TheItsNameless
     - MedicalJewel105
     - QuazChick
+    - Andexter8
 ---
 
 Now that you have the wiki set up locally, you can edit the files right on your device. If you don't know how to work with VSCode, there are some very good videos from Microsoft itself [here](https://code.visualstudio.com/docs).
@@ -213,6 +214,20 @@ A dangerous place
 :::danger STOP!
 A dangerous place
 :::
+
+### Syntax highlighting on inline code blocks
+
+The wiki has support for syntax highlighting on inline code blocks.
+
+Here is an example of how to use it:
+
+```md
+`console.log("Hello World!");`{lang=js}
+```
+
+The above example will render as:
+
+`console.log("Hello World!");`{lang=js}
 
 ### Links
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/fadeb8d5-d9e8-49ca-acd4-a7c231a9153c)
This adds support for syntax highlighting on inline code blocks.
It also adds documentation on how to use it to the `contribute-style.md` page.