### PR TITLE
docs: update active server softwares

### DIFF
--- a/docs/public/assets/tables/servers/server-software/active_software.json
+++ b/docs/public/assets/tables/servers/server-software/active_software.json
@@ -48,18 +48,6 @@
       "type": "BDS-based"
     },
     {
-      "name": "[JSPrismarine](https://github.com/JSPrismarine/JSPrismarine)",
-      "description": "Dedicated Minecraft Bedrock Edition server written in TypeScript.",
-      "languages": "TypeScript",
-      "type": "Custom"
-    },
-    {
-      "name": "[JukeBoxMC](https://github.com/LucGamesYT/JukeboxMC)",
-      "description": "A Minecraft Bedrock Edition Server Software.",
-      "languages": "Java",
-      "type": "Custom"
-    },
-    {
       "name": "[LeviLamina](https://github.com/LiteLDev/LeviLamina)",
       "description": "A lightweight, modular and versatile mod loader for Minecraft Bedrock Edition.",
       "languages": "C++",
@@ -99,18 +87,6 @@
       "name": "[PowerNukkitX](https://github.com/PowerNukkitX/PowerNukkitX)",
       "description": "Feature-rich, highly customizable third-party server software for Minecraft: Bedrock Edition.",
       "languages": "Java, JavaScript",
-      "type": "Custom"
-    },
-    {
-      "name": "[RAstra](https://github.com/bedrock-crustaceans/RAstra)",
-      "description": "Modern Minecraft Bedrock Server Software written in Rust.",
-      "languages": "Rust, JavaScript, TypeScript",
-      "type": "Custom"
-    },
-    {
-      "name": "[Sculk](https://github.com/sculkmp/Sculk)",
-      "description": "Sculk-Powered Minecraft: Bedrock Edition Server Software.",
-      "languages": "Java",
       "type": "Custom"
     },
     {

--- a/docs/public/assets/tables/servers/server-software/discontinued_software.json
+++ b/docs/public/assets/tables/servers/server-software/discontinued_software.json
@@ -255,6 +255,18 @@
       "type": "Custom"
     },
     {
+      "name": "[JSPrismarine](https://github.com/JSPrismarine/JSPrismarine)",
+      "description": "Dedicated Minecraft Bedrock Edition server written in TypeScript.",
+      "languages": "TypeScript",
+      "type": "Custom"
+    },
+    {
+      "name": "[JukeBoxMC](https://github.com/LucGamesYT/JukeboxMC)",
+      "description": "A Minecraft Bedrock Edition Server Software.",
+      "languages": "Java",
+      "type": "Custom"
+    },
+    {
       "name": "[LeafMCBE](https://github.com/LeafMCBE/LeafMCBE)",
       "description": "A Minecraft: Bedrock Server Software written in TypeScript",
       "languages": "TypeScript",
@@ -421,6 +433,12 @@
       "type": "Custom"
     },
     {
+      "name": "[RAstra](https://github.com/bedrock-crustaceans/RAstra)",
+      "description": "Modern Minecraft Bedrock Server Software written in Rust.",
+      "languages": "Rust, JavaScript, TypeScript",
+      "type": "Custom"
+    },
+    {
       "name": "[Rockit-LMS](https://github.com/cr0sh/Rockit-LMS)",
       "description": "Lightweight MC:PE server.",
       "languages": "Go",
@@ -430,6 +448,12 @@
       "name": "[Saddle](https://github.com/saddlemc/saddle)",
       "description": "Modular server software for Minecraft Bedrock Edition written in Go",
       "languages": "Go",
+      "type": "Custom"
+    },
+    {
+      "name": "[Sculk](https://github.com/sculkmp/Sculk)",
+      "description": "Sculk-Powered Minecraft: Bedrock Edition Server Software.",
+      "languages": "Java",
       "type": "Custom"
     },
     {


### PR DESCRIPTION
Removed from the active list due to inactivity over the past six months:

* JukeboxMC
* RAstra
* Sculk

Removed from the active list due to lack of support for the latest game version and no major feature updates (aside from dependency bumps) in the past six months:

* JSPrismarine
