### PR TITLE
Update useful-links.md

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -60,7 +60,7 @@ Important links have a ⭐.
 -   [Mcblend (Blender Plugin)](https://github.com/Nusiq/mcblend)
 -   [NBT Editor](https://www.universalminecrafteditor.com/)
 -   [NBT Studio](https://github.com/tryashtar/nbt-studio)
--   [SuitcaseJS (MCPack Compressor)](https://github.com/TBroz15/SuitcaseJS)
+-   [TesserPack (Pack Optimizer)](https://github.com/TBroz15/TesserPack)
 -   [World Converter (Paid)](https://www.universalminecraftconverter.com/download)
 
 ## Bedrock Tools Websites


### PR DESCRIPTION
Removes link to SuitcaseJS as it is deprecated.

Adds Github link to TesserPack, a build tool for optimizing Minecraft bedrock packs. It offers similar functionality as SuitcaseJS.