### PR TITLE
Updated recipes.md expanded potion effects list

### DIFF
--- a/docs/loot/recipes.md
+++ b/docs/loot/recipes.md
@@ -263,6 +263,10 @@ These identifiers are not usable in the object notation, only the string notatio
 -   `slow_falling`
 -   `turtle_master`
 -   `wither`
+-   `infested`
+-   `oozing`
+-   `weaving`
+-   `wind_charged`
 
 Where supported, `long_` and `strong_` prefixes may be used to designate modified potions, such as `minecraft:potion_type:strong_poison`.
 


### PR DESCRIPTION
Extended the list of potion identifiers to include the following:

wind_charged
infested
weaving
oozing

They all work with brewing_mix recipes, format version 1.17.41