### PR TITLE
Unit typo fix.

### DIFF
--- a/docs/meta/addon-performance.md
+++ b/docs/meta/addon-performance.md
@@ -193,7 +193,7 @@ Your best bet to resolve this issue is to split your trades in half and move the
 
 ### Streaming
 
--   As general guidance, sounds over 500kb in size or 1 minute in length should be streamed
+-   As general guidance, sounds over 500kB in size or 1 minute in length should be streamed
 
 ## Redstone
 


### PR DESCRIPTION
Fixed incorrect unit.
`kb` with a lowercase b refers to kilo*bits* when this was likely meant to be kilo*bytes*, the b should be capital in that case (`kB`).