### PR TITLE
Fix invalid item example: components cannot be empty (added required minecraft:icon)

### DIFF
--- a/docs/items/items-intro.md
+++ b/docs/items/items-intro.md
@@ -46,7 +46,12 @@ Below is the **minimum** behavior-side code to get a custom item into the creati
                 "category": "items"
             }
         },
-        "components": {} // Must be here, even if empty!
+        "components": {
+            // Minecraft requires at least one component such as:
+            // - minecraft:icon
+            // - or minecraft:block_placer with replace_block_item == true
+          "minecraft:icon": "wiki:custom_item"
+        }
     }
 }
 ```


### PR DESCRIPTION
### ✔ What this PR changes

* Updated the example to include a valid component (`minecraft:icon`).
* Added a clarifying comment explaining why a component is required.

### ✔ Why this is needed

The existing example in the documentation is not functional in Minecraft 1.21.120+.
This update ensures the example reflects actual engine requirements and prevents confusion for developers creating custom items.

Fixes #1125