### PR TITLE
Change 'deals_damage' value from false to 'no'

### DIFF
--- a/docs/blocks/fake-blocks.md
+++ b/docs/blocks/fake-blocks.md
@@ -47,7 +47,7 @@ Those components below are required to make the entity act as a block, and also 
     "minecraft:damage_sensor": {
         "triggers": [
             {
-                "deals_damage": false,
+                "deals_damage": "no",
                 "cause": "all"
             }
         ]
@@ -188,7 +188,7 @@ system.beforeEvents.startup.subscribe(({ blockComponentRegistry }) => {
             "minecraft:damage_sensor": {
                 "triggers": {
                     "cause": "all",
-                    "deals_damage": false
+                    "deals_damage": "no"
                 }
             }
         },
@@ -262,7 +262,7 @@ And now we have to add a new render controller. This is going to select differen
                     "texture.destroy_stage_2",
                     "texture.destroy_stage_1",
                     "texture.destroy_stage_0",
-                    "texture.normal"
+                    "texture.default"
                 ]
             }
         },

--- a/docs/blocks/fake-blocks.md
+++ b/docs/blocks/fake-blocks.md
@@ -161,13 +161,12 @@ system.beforeEvents.startup.subscribe(({ blockComponentRegistry }) => {
 
 ```json
 {
-    "format_version": "1.13.0",
+    "format_version": "1.26.0",
     "minecraft:entity": {
         "description": {
             "identifier": "wiki:dummy_align", // The dummy entity is used to avoid triggering the entity_spawned event in the original entity.
             "is_spawnable": false,
-            "is_summonable": true,
-            "is_experimental": false
+            "is_summonable": true
         },
         "component_groups": {
             "transform": {


### PR DESCRIPTION
Changes made:
```json
"minecraft:damage_sensor": {
  "deals_damage": "no" // this has to be string, not Boolean
}
```

Also fixed mismatched texture names between render controller and entity definition:
- Entity:
  - `texture.default`

- Render controller:
  - `texture.normal`

- Final version (both):
  - `texture.default`

This can lead into confusions **(it happended to me).**