### PR TITLE
Add "melee_spear" to enchantable component

### DIFF
--- a/docs/items/item-components.md
+++ b/docs/items/item-components.md
@@ -384,6 +384,7 @@ Type: Object
 | `fishing_rod`   |
 | `flintsteel`    |
 | `hoe`           |
+| `melee_spear`   |
 | `pickaxe`       |
 | `shears`        |
 | `shield`        |


### PR DESCRIPTION
The item component "minecraft:enchantable" allows for the slot "melee_spear" to be used in item versions 1.21.100 and all versions after.

This allows the item to obtain the same enchantments the vanilla spear toolset can use. All of which are functional.