### PR TITLE
Add the "pack_scope" string to the resource pack Manifest section

### DIFF
--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -179,7 +179,7 @@ When you are finished, it should look something like this:
 
 ## RP Manifest
 
-The next step is to create the `manifest.json` for the RP. The format for a resource-pack manifest is nearly identical to a BP manifests except that the `type` is `resources`, which marks the pack as a _Resource Pack_.
+The next step is to create the `manifest.json` for the RP. The format for a resource-pack manifest is nearly identical to a BP manifests except that the `type` is `resources`, which marks the pack as a _Resource Pack_ and the optional `pack_scope` which specifies whether this resource pack can be used across the game or at an individual world level.  
 
 Copy the following code into your newly created `RP/manifest.json` and insert your own UUIDs.
 
@@ -191,6 +191,7 @@ Copy the following code into your newly created `RP/manifest.json` and insert yo
     "header": {
         "name": "pack.name",
         "description": "pack.description",
+        "pack_scope": "any", // Can be "any", "global" or "world"
         "uuid": "...",
         "version": "1.0.0",
         "min_engine_version": "1.26.10"

--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -179,7 +179,9 @@ When you are finished, it should look something like this:
 
 ## RP Manifest
 
-The next step is to create the `manifest.json` for the RP. The format for a resource-pack manifest is nearly identical to a BP manifests except that the `type` is `resources`, which marks the pack as a _Resource Pack_ and the optional `pack_scope` which specifies whether this resource pack can be used across the game or at an individual world level.  
+The next step is to create the `manifest.json` for the RP.
+The format for a resource pack manifest is nearly identical to a BP manifest except that the module `type` is `"resources"`{lang=json}, which marks the pack as a _resource pack_.
+Additionally, we specify a `pack_scope` of `"world"`{lang=json} which prevents the pack from being activated outside of worlds.
 
 Copy the following code into your newly created `RP/manifest.json` and insert your own UUIDs.
 
@@ -191,10 +193,10 @@ Copy the following code into your newly created `RP/manifest.json` and insert yo
     "header": {
         "name": "pack.name",
         "description": "pack.description",
-        "pack_scope": "any", // Can be "any", "global" or "world"
         "uuid": "...",
         "version": "1.0.0",
-        "min_engine_version": "1.26.10"
+        "min_engine_version": "1.26.10",
+        "pack_scope": "world" // Can be "any" (default), "global" or "world"
     },
     "modules": [
         {


### PR DESCRIPTION
Added "pack_scope" to the resource pack Manifest section

See following:
https://learn.microsoft.com/en-us/minecraft/creator/reference/content/addonsreference/packmanifest?view=minecraft-bedrock-stable#header

"For resource packs, an optional string that specifies whether this resource pack can be used across the game or at an individual world level. Valid values are "world", which specifies that a pack is only addable in the context of a world "global", which means that a pack is only addable across the game, and "any" which indicates that a pack can apply either across the game or to a specific world. If not specified, this is interpreted as "any"."