### PR TITLE
Clarify on_open/on_close mapping to button modes

### DIFF
--- a/docs/entities/npc-dialogue.md
+++ b/docs/entities/npc-dialogue.md
@@ -59,7 +59,7 @@ The text to display in the speech bubble. Optional.
 Array of command strings to be run when the dialogue is opened. Optional.
 
 :::tip
-In the in-game NPC visual editor, this corresponds to the **"on enter"** button mode.
+In the NPC's in-game Advanced Settings, this corresponds to the **"on enter"** button mode.
 :::
 
 <CodeHeader></CodeHeader>
@@ -75,7 +75,7 @@ In the in-game NPC visual editor, this corresponds to the **"on enter"** button 
 Array of command strings to be run when the dialogue is closed. Optional.
 
 :::tip
-In the in-game NPC visual editor, this corresponds to the **"on exit"** button mode.
+In the NPC's in-game Advanced Settings, this corresponds to the **"on exit"** button mode.
 :::
 
 <CodeHeader></CodeHeader>

--- a/docs/entities/npc-dialogue.md
+++ b/docs/entities/npc-dialogue.md
@@ -13,6 +13,7 @@ mentions:
     - Sprunkles137
     - ThomasOrs
     - QuazChick
+    - MindfulLearner
 ---
 
 Non-Player Characters, or NPCs are villager-like entities that can be given a dialogue with a message and multiple buttons.
@@ -57,6 +58,10 @@ The text to display in the speech bubble. Optional.
 
 Array of command strings to be run when the dialogue is opened. Optional.
 
+:::tip
+In the in-game NPC visual editor, this corresponds to the **"on enter"** button mode.
+:::
+
 <CodeHeader></CodeHeader>
 
 ```json
@@ -68,6 +73,10 @@ Array of command strings to be run when the dialogue is opened. Optional.
 ### Close Commands
 
 Array of command strings to be run when the dialogue is closed. Optional.
+
+:::tip
+In the in-game NPC visual editor, this corresponds to the **"on exit"** button mode.
+:::
 
 <CodeHeader></CodeHeader>
 


### PR DESCRIPTION
# Summary

- Added tips to the `Open Commands` and `Close Commands sections` of the NPC Dialogue page clarifying that these correspond to the `"on enter"` and `"on exit"` button modes in Minecraft's in-game NPC visual editor.

# Motivation

The visual editor uses different terminology (`on enter` / `on exit`) than the JSON format (`on_open_commands` / `on_close_commands`), which can be confusing for creators switching between the two.

# Remarks 

I'm doing some test before to confirm this. 