### PR TITLE
`minecraft:has_fence_connections`

### DIFF
--- a/docs/public/assets/tables/blocks/vanilla-block-tags/tags.json
+++ b/docs/public/assets/tables/blocks/vanilla-block-tags/tags.json
@@ -90,14 +90,6 @@
       ]
     },
     {
-      "tag": "`minecraft:has_fence_connections`",
-      "vanilla_usage": [],
-      "functionality": [
-        "Used to identify a custom block as a block that creates connections like a fence; this tag is required to create connections between custom and vanilla fences.",
-        "Unused by vanilla blocks, but wooden fences _behave_ as if they have this tag."
-      ]
-    },
-    {
       "tag": "`minecraft:crop`",
       "vanilla_usage": [
         "`minecraft:beetroot`",
@@ -211,6 +203,13 @@
       "tag": "`gravel`",
       "vanilla_usage": ["`minecraft:gravel`", "`minecraft:suspicious_gravel`"],
       "functionality": "Allows Bamboo to be placed on the block."
+    },
+    {
+      "tag": "`minecraft:has_fence_connections`",
+      "functionality": [
+        "Used to identify a custom block as a block that creates connections like a fence; this tag is required to create connections between custom and vanilla fences.",
+        "Unused by vanilla blocks, but wooden fences _behave_ as if they have this tag."
+      ]
     },
     {
       "tag": "`iron_pick_diggable`",

--- a/docs/public/assets/tables/blocks/vanilla-block-tags/tags.json
+++ b/docs/public/assets/tables/blocks/vanilla-block-tags/tags.json
@@ -90,6 +90,14 @@
       ]
     },
     {
+      "tag": "`minecraft:has_fence_connections`",
+      "vanilla_usage": [],
+      "functionality": [
+        "Used to identify a custom block as a block that creates connections like a fence; this tag is required to create connections between custom and vanilla fences.",
+        "Unused by vanilla blocks, but wooden fences _behave_ as if they have this tag."
+      ]
+    },
+    {
       "tag": "`minecraft:crop`",
       "vanilla_usage": [
         "`minecraft:beetroot`",


### PR DESCRIPTION
This documents the `minecraft:has_fence_connections` tag. Note that this tag is not used by any vanilla blocks, but it does have special behaviors.