### PR TITLE
update `useful-links.md`

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -16,6 +16,7 @@ mentions:
     - JaylyDev
     - zheaEvyline
     - phoenixr-codes
+    - Aevarkan
 description: Useful links for developing add-ons.
 ---
 
@@ -57,14 +58,15 @@ Important links have a ⭐.
 -   [Bedrock World Editor (Free Open-Source Bedrock NBT/World Editor)](https://github.com/8Crafter-Studios/Bedrock-World-Editor)
 -   [Chunker (World Converter)](https://chunker.app/)
 -   [CoreCoder (Code Editor)](https://hanprog.itch.io/core-coder)
+-   [Dialogue Node Editor (VSCode Extension)](https://marketplace.visualstudio.com/items?itemName=aevarkan.bedrock-dialogue-node-editor)
 -   [Feature Rule Generator v2 (Free Version)](https://drive.google.com/file/d/1rwQTtzgpWiqCS9ecO_j-qcxjdQvWSXgi/view)
 -   [Feature Rule Generator v2 (Paid Version)](https://machine-builder.itch.io/frg-v2)
 -   [Mcblend (Blender Plugin)](https://github.com/Nusiq/mcblend)
--   [NBT Editor](https://www.universalminecrafteditor.com/)
 -   [NBT Studio](https://github.com/tryashtar/nbt-studio)
+-   [NBT Workbench](https://github.com/RealRTTV/nbtworkbench)
 -   [Ore UI Customizer App (Allows you to modify Ore UI)](https://github.com/8Crafter-Studios/Ore-UI-Customizer-App)
 -   [TesserPack (Pack Optimizer)](https://github.com/TBroz15/TesserPack)
--   [World Converter (Paid)](https://www.universalminecraftconverter.com/download)
+-   [Universal Minecraft Tool (Paid)](https://www.universalminecrafttool.com/)
 
 ## Bedrock Tools Websites
 
@@ -147,8 +149,9 @@ These packs are published by the open-source community.
 
 ## Add-On Marketplaces & Links
 
--   ⭐ [Minecraft Marketplace](https://www.minecraft.net/en-us/marketplace)
+-   ⭐ [Minecraft Marketplace](https://www.minecraft.net/marketplace)
 -   ⭐ [MCPEDL](http://mcpedl.com/?cookie_check=1)
+-   ⭐ [CurseForge](https://www.curseforge.com/minecraft-bedrock)
 -   ⭐ [Bucket of Crabs (Marketplace Joblist)](https://www.bucketofcrabs.net/)
 -   [CubitosMC](https://www.cubitosmc.com/)
 -   [MCDLHub](https://mcdlhub.com/)


### PR DESCRIPTION
Changes:
- added my [VSCode extension](https://marketplace.visualstudio.com/items?itemName=aevarkan.bedrock-dialogue-node-editor) as `Dialogue Node Editor (VSCode Extension)` — I don't see any other extension links, hope this is fine here!
- [Universal Minecraft Tool](https://www.universalminecrafttool.com/)
  - removed `NBT Editor` link (rebranding)
  - removed `World Converter` link (rebranding)
  - added `Universal Minecraft Tool` link
- added `NBT Workbench`
- added `CurseForge` as a ⭐ link in `Add-On Marketplaces & Links` — both MCPEDL and CurseForge are part of OverWolf, so I feel it's appropriate for CurseForge to have a star as MCPEDL does

- changed the `Minecraft Marketplace` link — I removed the `en-us` to let the user's browser pick the language the page opens in