### PR TITLE
Fix dialogue limitation note and clarify initiator in scriptEventReceive

### DIFF
--- a/docs/scripting/script-server.md
+++ b/docs/scripting/script-server.md
@@ -8,6 +8,7 @@ mentions:
     - ThomasOrs
     - kumja1
     - QuazChick
+    - MindfulLearner
 ---
 
 ::: warning
@@ -127,6 +128,40 @@ system.afterEvents.scriptEventReceive.subscribe((event) => {
     } = event;
 });
 ```
+
+:::tip
+When a `/scriptevent` is fired from an NPC dialogue button, `sourceType` will be `"NPCDialogue"`. In this case:
+
+- `initiator` is the **player** who clicked the button.
+- `sourceEntity` is the **NPC** entity that ran the command.
+
+Always use `initiator` to get the player in NPC-triggered events. `sourceEntity` will not be a player in this context.
+
+```js
+system.afterEvents.scriptEventReceive.subscribe((event) => {
+    const player = event.initiator; // the player, when fired from an NPC button
+    if (!player || player.typeId !== "minecraft:player") return;
+    // ...
+});
+```
+
+When the event comes from a command block, both `initiator` and `sourceEntity` will be `undefined`. If you need to target a specific player from a command block, pass the player name inside `message` and look them up:
+
+```js
+const player = world.getAllPlayers().find((p) => p.name === event.message.trim());
+```
+:::
+
+:::tip
+You can filter which namespaces a subscriber receives by passing a `namespaces` option. This avoids one large handler processing every scriptevent in your pack:
+
+```js
+system.afterEvents.scriptEventReceive.subscribe(
+    (event) => { /* only receives wiki:shop events */ },
+    { namespaces: ["wiki_shop"] }
+);
+```
+:::
 
 ## Scheduling
 
@@ -376,5 +411,4 @@ Script API can utilize new execute syntax to run commands with lots of if/unless
 
 **dialogue**
 
--   The Script API can't open the NPC dialogue to the player.
--   It cannot change the dialogue displayed by an NPC.
+-   There is no dedicated Script API method for NPC dialogues, however you can use `player.runCommand("dialogue open @e[tag=npc,r=5] @s scene_tag")` or `dimension.runCommand(...)` as a workaround to open and change NPC dialogues from script.


### PR DESCRIPTION
# Summary

- Fixed incorrect claim that Script API cannot open or change NPC dialogues. It can be done via `player.runCommand("dialogue open ...")`.
- Added a tip explaining that when a `/scriptevent` is fired from an NPC button, `event.initiator` is the player and `event.sourceEntity` is the NPC. Using `sourceEntity` to get the player is a common mistake that silently fails.
- Added a tip for the command block case where both `initiator` and `sourceEntity` are `undefined`.
- Added a tip for the `namespaces` filter option on `scriptEventReceive` subscribers.

# Motivation

The dialogue section falsely listed opening and changing NPC dialogues as unsupported, which is misleading. The `initiator` vs `sourceEntity` distinction in NPC-triggered scriptevents is a silent bug that breaks code with no obvious error message. Neither of these is documented anywhere on the wiki.

# Real world example

On a Bedrock survival server with 11 NPCs, every NPC button fires `/scriptevent namespace:action`. In the script handler, `ev.sourceEntity` is the NPC entity itself, not the player. Any code that tries `ev.sourceEntity` to get the player silently receives `undefined` or the wrong entity. The fix is `ev.initiator`, which is always the player who clicked.

The command block case came up when wiring a compass item to open a dashboard form. A command block fires `/scriptevent dashboard:open PlayerName` on item use. Since there is no `initiator` in that context, the player name is passed in the message and looked up with `world.getAllPlayers().find(p => p.name === ev.message.trim())`.

# Remarks

Tested on a live Bedrock server. `event.sourceType` is `"NPCDialogue"` when fired from an NPC button, confirming the `initiator`/`sourceEntity` behavior.