### PR TITLE
Add runTimeout warning and persistent menu pattern to Server Forms

### DIFF
--- a/docs/scripting/server-forms.md
+++ b/docs/scripting/server-forms.md
@@ -433,34 +433,9 @@ form.show(event.source).then(r => {
 
 ## Persistent Menus
 
-You can create menus that stay open after an action by re-calling the open function inside `.then()`. This is useful for shops or admin panels where the player should be able to perform multiple actions without reopening the menu.
+You can keep a menu open after each action by re-calling the open function inside `.then()`. This is useful for shops or admin panels where the player needs to make multiple choices in a row.
 
-```js
-function openShop(player) {
-    new ActionFormData()
-        .title("Shop")
-        .button("Buy Iron Sword — 5 gems")
-        .button("Buy Bow — 8 gems")
-        .button("Close")
-        .show(player)
-        .then((r) => {
-            if (r.canceled || r.selection === 2) return;
-
-            if (r.selection === 0) {
-                // handle iron sword purchase...
-            } else if (r.selection === 1) {
-                // handle bow purchase...
-            }
-
-            // reopen the shop after the action
-            system.runTimeout(() => openShop(player), 1);
-        })
-        .catch(() => {});
-}
-```
-
-:::tip
-The `.body()` text is computed each time the function is called. This means you can display live data such as a player's current balance by building the body string at call time rather than once at startup.
+The `.body()` text is recomputed on every call, so you can show live data like a current balance without any extra state management.
 
 ```js
 function openShop(player) {
@@ -469,8 +444,14 @@ function openShop(player) {
         .title("Shop")
         .body(`Your balance: ${gems} gems`)
         .button("Buy Iron Sword — 5 gems")
-        // ...
-        .show(player).then(...).catch(() => {});
+        .button("Close")
+        .show(player)
+        .then((r) => {
+            if (r.canceled || r.selection === 1) return;
+            // handle purchase...
+            system.runTimeout(() => openShop(player), 1);
+        })
+        .catch(() => {});
 }
 ```
 :::

--- a/docs/scripting/server-forms.md
+++ b/docs/scripting/server-forms.md
@@ -14,6 +14,7 @@ mentions:
     - SmokeyStack
     - ThomasOrs
     - kumja1
+    - MindfulLearner
 description: Create form UIs without the need for JSON UI-wrangling.
 ---
 
@@ -292,6 +293,25 @@ These forms will only open when no other UI is open. If you want to open the for
 
 Inside the if statement is where our form will be shown. Using `.show()`, the form will open. Inside the show function, you will need a player class as an argument. After we show the form, we can use `.then()` to save the response of player.
 
+:::warning
+When opening a form from a `scriptEventReceive` handler or from `world.afterEvents.itemUse`, calling `form.show(player)` directly may cause the form not to appear. Wrap it in `system.runTimeout(() => form.show(player).then(...), 1)` to defer the call by one tick.
+
+```js
+system.afterEvents.scriptEventReceive.subscribe((event) => {
+    const player = event.initiator;
+    if (!player) return;
+    system.runTimeout(() => {
+        new ActionFormData()
+            .title("Menu")
+            .button("Option 1")
+            .show(player)
+            .then((r) => { if (r.canceled) return; })
+            .catch(() => {});
+    }, 1);
+});
+```
+:::
+
 ```js
 form.show(event.source)
     .then((r) => {
@@ -410,3 +430,47 @@ form.show(event.source).then(r => {
 	console.error(e, e.stack);
 });
 ```
+
+## Persistent Menus
+
+You can create menus that stay open after an action by re-calling the open function inside `.then()`. This is useful for shops or admin panels where the player should be able to perform multiple actions without reopening the menu.
+
+```js
+function openShop(player) {
+    new ActionFormData()
+        .title("Shop")
+        .button("Buy Iron Sword — 5 gems")
+        .button("Buy Bow — 8 gems")
+        .button("Close")
+        .show(player)
+        .then((r) => {
+            if (r.canceled || r.selection === 2) return;
+
+            if (r.selection === 0) {
+                // handle iron sword purchase...
+            } else if (r.selection === 1) {
+                // handle bow purchase...
+            }
+
+            // reopen the shop after the action
+            system.runTimeout(() => openShop(player), 1);
+        })
+        .catch(() => {});
+}
+```
+
+:::tip
+The `.body()` text is computed each time the function is called. This means you can display live data such as a player's current balance by building the body string at call time rather than once at startup.
+
+```js
+function openShop(player) {
+    const gems = countGems(player);
+    new ActionFormData()
+        .title("Shop")
+        .body(`Your balance: ${gems} gems`)
+        .button("Buy Iron Sword — 5 gems")
+        // ...
+        .show(player).then(...).catch(() => {});
+}
+```
+:::


### PR DESCRIPTION
# Summary

- Added a warning that calling `form.show(player)` directly inside `scriptEventReceive` or `world.afterEvents.itemUse` may cause the form not to appear. The fix is to wrap the call in `system.runTimeout(..., 1)`.
- Added a new section **Persistent Menus** showing how to re-call the open function inside `.then()` to keep a menu open after each action.
- Added a tip showing that `.body()` is computed at call time, so live data like a player balance can be displayed dynamically.

# Motivation

The `runTimeout` requirement is a silent bug that is not mentioned anywhere. Developers spend time debugging why their form never appears after an NPC interaction or item use. The persistent menu and dynamic body patterns are common needs with no existing reference on the wiki.

# Real world example

On a Bedrock survival server, five merchant NPCs (general shop, blacksmith, farmer, alchemist, egg merchant) each open an ActionFormData shop when a button is clicked. Without the `system.runTimeout(..., 1)` wrapper, the shop form would silently fail to open on some clients.

Each shop form re-opens itself after every buy or sell action so the player can make multiple purchases without closing and reopening. The body of each form shows the player's current gem balance, computed fresh each time the function is called so the number updates after every transaction.

# Remarks

All patterns confirmed working on a live Bedrock server.