### PR TITLE
Document entity.remove() vs entity.kill() difference

### DIFF
--- a/docs/scripting/script-server.md
+++ b/docs/scripting/script-server.md
@@ -290,6 +290,28 @@ world.setDynamicProperty("player_score", 100); // set a property with a number v
 const playerScore = world.getDynamicProperty("player_score"); // get the previously set property- will return 100.
 ```
 
+## Removing Entities
+
+The Script API provides two ways to remove an entity, which behave differently:
+
+- `entity.kill()` — triggers the entity's death sequence. It fires the `entityDie` event, causes drops, plays the death animation, and counts as a kill for scoreboard objectives.
+- `entity.remove()` — removes the entity immediately and silently. No death event, no drops, no animation.
+
+```js
+// Use kill() when you want the full death behavior (drops, events, kill credit)
+zombie.kill();
+
+// Use remove() when you want silent cleanup with no side effects
+// For example, removing dropped item entities from the ground
+for (const item of dimension.getEntities({ type: "minecraft:item" })) {
+    item.remove();
+}
+```
+
+:::tip
+Using `kill()` on dropped item entities will fire `entityDie` for each one and may trigger unintended listeners. Always use `remove()` for item cleanup.
+:::
+
 ## Running Commands
 
 `Entity.runCommandAsync()` or `Dimension.runCommandAsync()` allows the API to run a particular command asynchronously from the context of the broader dimension.


### PR DESCRIPTION
# Summary

- Added a new section **Removing Entities** to the Script Core Features page.
- Documents `entity.kill()` vs `entity.remove()` with a clear explanation of when each should be used.
- Includes a tip warning against using `kill()` on dropped item entities during cleanup, since it fires `entityDie` for each one.

# Motivation

The difference between these two methods is not documented anywhere on the wiki. Developers who use `kill()` for item cleanup discover unexpected behavior (death events firing, scoreboard side effects) without a clear explanation of why.

# Real world example

On a Bedrock survival server, a cleanup routine runs every 1 to 2 hours to remove items dropped on the ground across all three dimensions (overworld, nether, the end). Using `entity.kill()` for this would fire the `entityDie` event for every dropped item, which would interfere with kill-tracking quest logic. Switching to `entity.remove()` resolved the interference completely since the event is never fired.

The same server also runs a mob purge every 15 to 30 minutes that eliminates hostile mobs. That routine intentionally uses `entity.kill()` so that death events fire and quest kill counters update correctly for any player who had an active kill quest at the time.

# Remarks

Confirmed on a live Bedrock server: `entity.remove()` on item entities does not fire `entityDie`, while `entity.kill()` does.