### PR TITLE
Document inventory helpers for counting and removing items by multiple typeIds

### DIFF
--- a/docs/scripting/script-server.md
+++ b/docs/scripting/script-server.md
@@ -8,6 +8,7 @@ mentions:
     - ThomasOrs
     - kumja1
     - QuazChick
+    - MindfulLearner
 ---
 
 ::: warning
@@ -289,6 +290,65 @@ import { world } from "@minecraft/server";
 world.setDynamicProperty("player_score", 100); // set a property with a number value
 const playerScore = world.getDynamicProperty("player_score"); // get the previously set property- will return 100.
 ```
+
+## Inventory: Counting and Removing Items by Multiple TypeIds
+
+The `/clear` command does not support matching multiple item types in one call. When you need to count or remove items that span several `typeId` values (such as any color of wool, or any type of flower), you need to iterate the player's inventory manually.
+
+Using a `Set` for the allowed type IDs makes the lookup O(1) per slot:
+
+```js
+const WOOL_IDS = [
+    "minecraft:white_wool", "minecraft:orange_wool", "minecraft:magenta_wool",
+    "minecraft:light_blue_wool", "minecraft:yellow_wool", "minecraft:lime_wool",
+    "minecraft:pink_wool", "minecraft:gray_wool", "minecraft:light_gray_wool",
+    "minecraft:cyan_wool", "minecraft:purple_wool", "minecraft:blue_wool",
+    "minecraft:brown_wool", "minecraft:green_wool", "minecraft:red_wool",
+    "minecraft:black_wool",
+];
+
+// Count how many items matching any of the given typeIds the player has
+function countItems(player, typeIds) {
+    const allowed = new Set(typeIds);
+    const container = player.getComponent("minecraft:inventory").container;
+    let total = 0;
+    for (let i = 0; i < container.size; i++) {
+        const item = container.getItem(i);
+        if (item && allowed.has(item.typeId)) total += item.amount;
+    }
+    return total;
+}
+
+// Remove exactly `amount` items from the player, consuming stacks as needed
+function clearItems(player, typeIds, amount) {
+    const allowed = new Set(typeIds);
+    const container = player.getComponent("minecraft:inventory").container;
+    let remaining = amount;
+    for (let i = 0; i < container.size && remaining > 0; i++) {
+        const item = container.getItem(i);
+        if (!item || !allowed.has(item.typeId)) continue;
+        const take = Math.min(item.amount, remaining);
+        item.amount -= take;
+        container.setItem(i, item.amount > 0 ? item : undefined);
+        remaining -= take;
+    }
+}
+```
+
+Usage example — check that the player has 8 of any wool color, then remove them:
+
+```js
+if (countItems(player, WOOL_IDS) >= 8) {
+    clearItems(player, WOOL_IDS, 8);
+    player.sendMessage("Quest complete!");
+}
+```
+
+:::tip
+`container.getItem(i)?.typeId` always returns the full namespaced ID, such as `"minecraft:white_wool"`. Items from third-party packs use their own namespace, for example `"mypacks:custom_item"`.
+
+Passing `undefined` to `container.setItem(i, undefined)` clears that slot entirely. This is required when reducing a stack to zero — setting `item.amount = 0` alone does not remove the item from the slot.
+:::
 
 ## Running Commands
 

--- a/docs/scripting/script-server.md
+++ b/docs/scripting/script-server.md
@@ -295,7 +295,7 @@ const playerScore = world.getDynamicProperty("player_score"); // get the previou
 
 The `/clear` command does not support matching multiple item types in one call. When you need to count or remove items that span several `typeId` values (such as any color of wool, or any type of flower), you need to iterate the player's inventory manually.
 
-Using a `Set` for the allowed type IDs makes the lookup O(1) per slot:
+Both helpers take an array of `typeId` strings and use a `Set` internally for fast lookups:
 
 ```js
 const WOOL_IDS = [
@@ -346,7 +346,9 @@ if (countItems(player, WOOL_IDS) >= 8) {
 
 :::tip
 `container.getItem(i)?.typeId` always returns the full namespaced ID, such as `"minecraft:white_wool"`. Items from third-party packs use their own namespace, for example `"mypacks:custom_item"`.
+:::
 
+:::tip
 Passing `undefined` to `container.setItem(i, undefined)` clears that slot entirely. This is required when reducing a stack to zero — setting `item.amount = 0` alone does not remove the item from the slot.
 :::
 


### PR DESCRIPTION
# Summary

- Added a new section **Inventory: Counting and Removing Items by Multiple TypeIds** to the Script Core Features page.
- Documents `countItems` and `clearItems` helper patterns using a `Set` for efficient lookup across item variants.
- Includes a tip noting that `container.getItem(i)?.typeId` returns the full namespaced ID and that `container.setItem(i, undefined)` is required to clear a slot entirely.

# Motivation

The `/clear` command matches only one `typeId` at a time, so accepting any color of wool or any flower type requires iterating the inventory in script. This is a common requirement with no existing reference on the wiki. The partial stack removal behavior is also non-obvious and not documented.

# Real world example

On a Bedrock survival server, a decorator NPC named Sofia has several quests that accept item groups:

- "Blooming Garden": deliver any 16 flowers (16 different typeIds: dandelion, poppy, blue orchid, allium, etc.)
- "Warmth and Color": deliver any 8 wool excluding white (15 typeIds)
- "The Palette": deliver any 6 dyes (16 typeIds)
- "Glowing Windows": deliver any 32 stained glass (16 typeIds) plus 16 glowstone

Without iterating the inventory against a set of typeIds, these quests would require the player to hold one specific item color, which breaks the design. The `clearItems` function is used on delivery to consume the right quantity from whatever variants the player actually has in their inventory.

The same pattern is also used in the merchant sell screens, where selling "any wool" accepts all 16 colors in one transaction.

# Remarks

Confirmed working on a live Bedrock server across wool, flower, dye, candle, and stained glass variants.