### PR TITLE
Updated input_predicate structure to match schema

### DIFF
--- a/docs/loot/randomized-structure-loot.md
+++ b/docs/loot/randomized-structure-loot.md
@@ -176,9 +176,11 @@ A example of a chest having a loot table applied to all rotations.
             },
             "input_predicate": {
                 "predicate_type": "minecraft:blockstate_match",
-                "block": "minecraft:chest",
-                "states": {
-                    "minecraft:cardinal_direction": "north"
+                "block_state": {
+                    "name": "minecraft:chest",
+                    "states": {
+                        "minecraft:cardinal_direction": "north"
+                    }
                 }
             },
             "output_state": {
@@ -195,9 +197,11 @@ A example of a chest having a loot table applied to all rotations.
             },
             "input_predicate": {
                 "predicate_type": "minecraft:blockstate_match",
-                "block": "minecraft:chest",
-                "states": {
-                    "minecraft:cardinal_direction": "south"
+                "block_state": {
+                    "name": "minecraft:chest",
+                    "states": {
+                        "minecraft:cardinal_direction": "south"
+                    }
                 }
             },
             "output_state": {
@@ -214,9 +218,11 @@ A example of a chest having a loot table applied to all rotations.
             },
             "input_predicate": {
                 "predicate_type": "minecraft:blockstate_match",
-                "block": "minecraft:chest",
-                "states": {
-                    "minecraft:cardinal_direction": "east"
+                "block_state": {
+                    "name": "minecraft:chest",
+                    "states": {
+                        "minecraft:cardinal_direction": "east"
+                    }
                 }
             },
             "output_state": {
@@ -233,9 +239,11 @@ A example of a chest having a loot table applied to all rotations.
             },
             "input_predicate": {
                 "predicate_type": "minecraft:blockstate_match",
-                "block": "minecraft:chest",
-                "states": {
-                    "minecraft:cardinal_direction": "west"
+                "block_state": {
+                    "name": "minecraft:chest",
+                    "states": {
+                        "minecraft:cardinal_direction": "west"
+                    }
                 }
             },
             "output_state": {


### PR DESCRIPTION
When working on my jigsaw structure, I referenced the code on the wiki. I then found out that Minecraft's schema had been updated, therefore I'm suggesting updates to the code on the wiki.