### PR TITLE
Move PocketMine-MP and NetherGamesMC/PocketMine-MP to Discontinued Software

### DIFF
--- a/docs/public/assets/tables/servers/server-software/active_software.json
+++ b/docs/public/assets/tables/servers/server-software/active_software.json
@@ -60,12 +60,6 @@
       "type": "Custom"
     },
     {
-      "name": "[NetherGamesMC/PocketMine-MP](https://github.com/NetherGamesMC/PocketMine-MP)",
-      "description": "A multi protocol server software for Minecraft: Bedrock Edition in PHP.",
-      "languages": "C++",
-      "type": "Custom"
-    },
-    {
       "name": "[Nukkit PetteriM1 Edition](https://github.com/PetteriM1/NukkitPetteriM1Edition)",
       "description": "Add support for LevelDB, multiversion & more to Nukkit Minecraft Bedrock Edition server software.",
       "languages": "Java",
@@ -75,12 +69,6 @@
       "name": "[Nukkit-MOT](https://github.com/MemoriesOfTime/Nukkit-MOT)",
       "description": "Support for multiple versions of Nukkit Minecraft Bedrock Edition Server Software.",
       "languages": "Java",
-      "type": "Custom"
-    },
-    {
-      "name": "[PocketMine-MP](https://github.com/pmmp/PocketMine-MP)",
-      "description": "Custom server software for Minecraft: Bedrock, built from scratch in PHP, C and C++.",
-      "languages": "C, C++, PHP",
       "type": "Custom"
     },
     {

--- a/docs/public/assets/tables/servers/server-software/discontinued_software.json
+++ b/docs/public/assets/tables/servers/server-software/discontinued_software.json
@@ -362,6 +362,12 @@
       "type": "Custom"
     },
     {
+      "name": "[NetherGamesMC/PocketMine-MP](https://github.com/NetherGamesMC/PocketMine-MP)",
+      "description": "A multi protocol server software for Minecraft: Bedrock Edition in PHP.",
+      "languages": "C++",
+      "type": "Custom"
+    },
+    {
       "name": "[Netrex](https://github.com/NetrexMC/Netrex)",
       "description": "A powerful minecraft bedrock software written in Rust and Typescript with a powerful Typescript plugin API.",
       "languages": "Rust",
@@ -395,6 +401,12 @@
       "name": "[PieMC](https://github.com/PieMC-Dev/PieMC)",
       "description": "An exciting open-source project aimed at developing a powerful and customizable Minecraft Bedrock server software using Python",
       "languages": "Python",
+      "type": "Custom"
+    },
+    {
+      "name": "[PocketMine-MP](https://github.com/pmmp/PocketMine-MP)",
+      "description": "Custom server software for Minecraft: Bedrock, built from scratch in PHP, C and C++.",
+      "languages": "C, C++, PHP",
       "type": "Custom"
     },
     {


### PR DESCRIPTION
Moves these projects to Discontinued Software as they are no longer maintained.

- NetherGamesMC/PocketMine-MP
- PocketMine-MP