### PR TITLE
Update Endstone description in active server software list

### DIFF
--- a/docs/public/assets/tables/servers/server-software/active_software.json
+++ b/docs/public/assets/tables/servers/server-software/active_software.json
@@ -43,7 +43,7 @@
     },
     {
       "name": "[Endstone](https://github.com/EndstoneMC/endstone)",
-      "description": "A High-level Plugin API for Modding Bedrock Dedicated Servers, in both Python and C++.",
+      "description": "A BDS-based Bedrock server software with full vanilla features and a Paper-like plugin API.",
       "languages": "C++, Python",
       "type": "BDS-based"
     },


### PR DESCRIPTION
Updates the Endstone entry in the active server software table.

The old wording ("A High-level Plugin API for Modding Bedrock Dedicated Servers") no longer describes the project. Endstone is a full BDS-based server software these days, not just an API surface — the plugin API is one part of it. The new text matches the description on the [Endstone repository](https://github.com/EndstoneMC/endstone).

`languages` and `type` are unchanged, and no other rows are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
