### PR TITLE
Add MapMC to the Bedrock tools list

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -17,6 +17,7 @@ mentions:
     - zheaEvyline
     - phoenixr-codes
     - Aevarkan
+    - xspring1982
 description: Useful links for developing add-ons.
 ---
 
@@ -87,6 +88,7 @@ Important links have a ⭐.
 -   [Textures to Glyph Tool](https://minato.beyondbedrock.org/web-apps/textures-to-glyph/)
 -   [.lang File Generator](https://solveddev.github.io/AnyLanguage/)
 -   [Manifest Generator](https://tools.pixelpoly.co/manifest-generator)
+-   [MapMC (Real-World Map to Bedrock .mcworld Generator, Paid)](https://mapmc.app/)
 -   [MCB/EDU .mcworld Builder](https://nchiari.github.io/Minecraft-Bedrock-Edu-World-Builder/)
 -   [MCBE Essentials](https://mcbe-essentials.github.io/)
 -   [.mcpack Generator](https://mcbe-essentials.github.io/instant-pack/)


### PR DESCRIPTION
## Summary

- add MapMC to **Useful Links → Bedrock Tools Websites**
- describe it accurately as a paid real-world map to Bedrock `.mcworld` generator
- add the contributor handle required by the page style

MapMC provides a hosted browser workflow for selecting a real-world area and exporting it as a Bedrock `.mcworld`, so it complements the existing world builders, packagers, and editors in this section.

Disclosure: I maintain MapMC.

## Validation

- `npm run lint`
- `npm run fastbuild`